### PR TITLE
修复 tboox.org 的链接

### DIFF
--- a/cn/index.html
+++ b/cn/index.html
@@ -275,7 +275,7 @@
 
 <ul>
   <li>邮箱：<a href="mailto:waruqi@gmail.com">waruqi@gmail.com</a></li>
-  <li>主页：<a href="https://www.tboox.org/cn">tboox.org</a></li>
+  <li>主页：<a href="https://tboox.org/cn">tboox.org</a></li>
   <li>社区：<a href="https://www.reddit.com/r/tboox/">Reddit论坛</a></li>
   <li>聊天：<a href="https://t.me/tbooxorg">Telegram群组</a>, <a href="https://gitter.im/tboox/tboox?utm_source=badge&amp;utm_medium=badge&amp;utm_campaign=pr-badge&amp;utm_content=badge">Gitter聊天室</a></li>
   <li>源码：<a href="https://github.com/xmake-io/xmake">Github</a>, <a href="https://gitee.com/tboox/xmake">Gitee</a></li>
@@ -286,7 +286,7 @@
 
 
       <footer class="site-footer">
-  <span class="site-footer-owner">Copyright (c) 2015-2018 <a href="https://www.tboox.org">tboox.org</a>.</span>
+  <span class="site-footer-owner">Copyright (c) 2015-2018 <a href="https://tboox.org">tboox.org</a>.</span>
   <span class="site-footer-power">
     <span>
         <!--Site powered by <a href="https://jekyllrb.com/">Jekyll</a> & <a href="https://pages.coding.me">Coding Pages</a>.-->

--- a/cn/pages/donation.html
+++ b/cn/pages/donation.html
@@ -178,7 +178,7 @@
 
 
       <footer class="site-footer">
-  <span class="site-footer-owner">Copyright (c) 2015-2018 <a href="https://www.tboox.org">tboox.org</a>.</span>
+  <span class="site-footer-owner">Copyright (c) 2015-2018 <a href="https://tboox.org">tboox.org</a>.</span>
   <span class="site-footer-power">
     <span>
         <!--Site powered by <a href="https://jekyllrb.com/">Jekyll</a> & <a href="https://pages.coding.me">Coding Pages</a>.-->

--- a/config.js
+++ b/config.js
@@ -29,7 +29,7 @@ docute.init({
         title: 'Manual', path: '/manual'
       },
       {
-        title: 'Articles', path: 'https://www.tboox.org/category/#xmake'
+        title: 'Articles', path: 'https://tboox.org/category/#xmake'
       },
       {
         title: 'Feedback', path: 'https://github.com/xmake-io/xmake/issues'
@@ -52,7 +52,7 @@ docute.init({
         title: '手册', path: '/zh/manual'
       },
       {
-        title: '文章', path: 'https://www.tboox.org/cn/category/#xmake'
+        title: '文章', path: 'https://tboox.org/cn/category/#xmake'
       },
       {
         title: '反馈', path: 'https://github.com/xmake-io/xmake/issues'

--- a/landing.html
+++ b/landing.html
@@ -275,7 +275,7 @@
 
 <ul>
   <li>Email：<a href="mailto:waruqi@gmail.com">waruqi@gmail.com</a></li>
-  <li>Homepage：<a href="https://www.tboox.org">tboox.org</a></li>
+  <li>Homepage：<a href="https://tboox.org">tboox.org</a></li>
   <li>Community：<a href="https://www.reddit.com/r/tboox/">/r/tboox on reddit</a></li>
   <li>ChatRoom：<a href="https://t.me/tbooxorg">Char on telegram</a>, <a href="https://gitter.im/tboox/tboox?utm_source=badge&amp;utm_medium=badge&amp;utm_campaign=pr-badge&amp;utm_content=badge">Chat on gitter</a></li>
   <li>Source Code：<a href="https://github.com/xmake-io/xmake">Github</a>, <a href="https://gitee.com/tboox/xmake">Gitee</a></li>
@@ -283,7 +283,7 @@
 
 
       <footer class="site-footer">
-  <span class="site-footer-owner">Copyright (c) 2015-2018 <a href="https://www.tboox.org">tboox.org</a>.</span>
+  <span class="site-footer-owner">Copyright (c) 2015-2018 <a href="https://tboox.org">tboox.org</a>.</span>
   <span class="site-footer-power">
     <span>
         <!--Site powered by <a href="https://jekyllrb.com/">Jekyll</a> & <a href="https://pages.coding.me">Coding Pages</a>.-->

--- a/landing/_config.yml
+++ b/landing/_config.yml
@@ -10,7 +10,7 @@ paginate:     1
 # About/contact
 author:
   name:       waruqi
-  url:        https://www.tboox.org 
+  url:        https://tboox.org 
 
 #Others
 markdown: kramdown

--- a/landing/index.cn.md
+++ b/landing/index.cn.md
@@ -212,7 +212,7 @@ target("test")
 ## 联系方式
 
 * 邮箱：[waruqi@gmail.com](mailto:waruqi@gmail.com)
-* 主页：[tboox.org](https://www.tboox.org/cn)
+* 主页：[tboox.org](https://tboox.org/cn)
 * 社区：[Reddit论坛](https://www.reddit.com/r/tboox/)
 * 聊天：[Telegram群组](https://t.me/tbooxorg), [Gitter聊天室](https://gitter.im/tboox/tboox?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 * 源码：[Github](https://github.com/xmake-io/xmake), [Gitee](https://gitee.com/tboox/xmake)

--- a/landing/index.md
+++ b/landing/index.md
@@ -212,7 +212,7 @@ Some projects using xmake:
 ## Contacts
 
 * Email：[waruqi@gmail.com](mailto:waruqi@gmail.com)
-* Homepage：[tboox.org](https://www.tboox.org)
+* Homepage：[tboox.org](https://tboox.org)
 * Community：[/r/tboox on reddit](https://www.reddit.com/r/tboox/)
 * ChatRoom：[Char on telegram](https://t.me/tbooxorg), [Chat on gitter](https://gitter.im/tboox/tboox?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 * Source Code：[Github](https://github.com/xmake-io/xmake), [Gitee](https://gitee.com/tboox/xmake)

--- a/pages/donation.html
+++ b/pages/donation.html
@@ -180,7 +180,7 @@
 
 
       <footer class="site-footer">
-  <span class="site-footer-owner">Copyright (c) 2015-2018 <a href="https://www.tboox.org">tboox.org</a>.</span>
+  <span class="site-footer-owner">Copyright (c) 2015-2018 <a href="https://tboox.org">tboox.org</a>.</span>
   <span class="site-footer-power">
     <span>
         <!--Site powered by <a href="https://jekyllrb.com/">Jekyll</a> & <a href="https://pages.coding.me">Coding Pages</a>.-->


### PR DESCRIPTION
https://www.tboox.org 没有正确的证书，会导致浏览器报警