### PR TITLE
Indicate plural form of the noun

### DIFF
--- a/manual.md
+++ b/manual.md
@@ -10,17 +10,17 @@ The interface is named according to some of the predefined specifications, which
 
 It's according to the following rules:
 
-| Interfaces            | Description                                                       |
-| --------------------- | ----------------------------------------------------------------- |
-| `is_`/`has_` + xxx    | Condition interfaces                                              |
-| `set_` + xxx          | Set and override the previous settings                            |
-| `add_` + xxx          | Set and append settings                                           |
-| `s` + xxx             | Support multi-parameters, .e.g：`add_files("*.c", "test.cpp")`    |
-| `on_` + xxx           | Set and override builtin script                                   |
-| `before_` + xxx       | Set and run this script before running builtin-script             |
-| `after_` + xxx        | Set and run this script after running builtin-script              |
-| `scope("name")`       | Define a description scope, .e.g `target("xxx")`, `option("xxx")` |
-| scope/settings        | Indentation with spaces                                           |
+| Interfaces            | Description                                                      |
+| --------------------- | ---------------------------------------------------------------- |
+| `is_`/`has_` + xxx    | Condition interfaces                                             |
+| `set_` + xxx          | Set and override the previous settings                           |
+| `add_` + xxx          | Set and append settings                                          |
+| `…s` + xxx *(plural)* | Support multi-parameters, .e.g：`add_files("*.c", "test.cpp")`   |
+| `on_` + xxx           | Set and override builtin script                                  |
+| `before_` + xxx       | Set and run this script before running builtin-script            |
+| `after_` + xxx        | Set and run this script after running builtin-script             |
+| `scope("name")`       | Define a description scope, .e.g `target("xxx")`, `option("xxx")`|
+| scope/settings        | Indentation with spaces                                          |
 
 ## Documentation
 


### PR DESCRIPTION
Make it clearer that `s` is meant to denote a plural suffix of a noun.
