### PR TITLE
Add package interface documentation

### DIFF
--- a/_sidebar.md
+++ b/_sidebar.md
@@ -42,6 +42,7 @@
   - [Custom Rule](manual/custom_rule.md)
   - [Custom Toolchain](manual/custom_toolchain.md)
   - [Package Dependencies](manual/package_dependencies.md)
+  - [Package Interface](manual/package_interface.md)
   - [Builtin Variables](manual/builtin_variables.md)
   - [Builtin Modules](manual/builtin_modules.md)
   - [Extension Modules](manual/extension_modules.md)

--- a/manual/package_interface.md
+++ b/manual/package_interface.md
@@ -26,6 +26,7 @@ This page describes the interface for `package` of functions like `on_load()`, `
 | [package:dep](#packagedep)                     | Get a dependency of the package                                              | >= 2.2.3           |
 | [package:deps](#packagedeps)                   | Get all dependencies of the package                                          | >= 2.1.7           |
 | [package:sourcehash](#packagesourcehash)       | Get the sha256 checksum of an URL alias                                      | >= 2.3.2           |
+| [package:kind](#packagekind)                   | Get the kind of the package                                                  | >= 2.1.7           |
 
 #### package:name
 
@@ -265,3 +266,10 @@ package:sourcehash("example")
 -- or so
 package:sourcehash(package:url_alias(package:urls()[1]))
 ```
+
+#### package:kind
+
+- Get the kind of the package. Can be any of:
+  + binary
+  + toolchain (is also binary)
+  + library (default)

--- a/manual/package_interface.md
+++ b/manual/package_interface.md
@@ -1,11 +1,12 @@
 
 This page describes the interface for `package` of functions like `on_load()`, `on_install()` or `on_test()` of the [Package Dependencies](manual/package_dependencies.md)
 
-| Interface                    | Description                   | Supported Versions |
-| ---------------------------- | ----------------------------- | ------------------ |
-| [package:name](#packagename) | Get the name of the package   | >= 2.2.5           |
-| [package:get](#packageget)   | Get the values of the package | >= 2.1.6           |
-| [package:set](#packageset)   | Set the values of the package | >= 2.1.6           |
+| Interface                    | Description                      | Supported Versions |
+| ---------------------------- | -------------------------------- | ------------------ |
+| [package:name](#packagename) | Get the name of the package      | >= 2.2.5           |
+| [package:get](#packageget)   | Get the values of the package    | >= 2.1.6           |
+| [package:set](#packageset)   | Set the values of the package    | >= 2.1.6           |
+| [package:add](#packageadd)   | Add to the values of the package | >= 2.2.5           |
 
 #### package:name
 
@@ -35,4 +36,17 @@ package:set("deps", {"python"})
 package:set("links", {"sdl2"})
 -- set the defined macros
 package:set("defines", {"SDL_MAIN_HANDLED"})
+```
+
+#### package:add
+
+- Add to the values of the package by name
+
+```lua
+-- add dependencies
+package:add("deps", "python")
+-- add links
+package:add("links", "sdl2")
+-- add defined macros
+package:add("defines", "SDL_MAIN_HANDLED")
 ```

--- a/manual/package_interface.md
+++ b/manual/package_interface.md
@@ -1,17 +1,18 @@
 
 This page describes the interface for `package` of functions like `on_load()`, `on_install()` or `on_test()` of the [Package Dependencies](manual/package_dependencies.md)
 
-| Interface                                  | Description                         | Supported Versions |
-| ------------------------------------------ | ----------------------------------- | ------------------ |
-| [package:name](#packagename)               | Get the name of the package         | >= 2.2.5           |
-| [package:get](#packageget)                 | Get the values of the package       | >= 2.1.6           |
-| [package:set](#packageset)                 | Set the values of the package       | >= 2.1.6           |
-| [package:add](#packageadd)                 | Add to the values of the package    | >= 2.2.5           |
-| [package:license](#packagelicense)         | Get the license of the package      | >= 2.3.9           |
-| [package:description](#packagedescription) | Get the description of the package  | >= 2.2.3           |
-| [package:plat](#packageplat)               | Get the platform of the package     | >= 2.2.2           |
-| [package:arch](#packagearch)               | Get the architecture of the package | >= 2.2.2           |
-| [package:targetos](#packagetargetos)       | Get the targeted OS of the package  | >= 2.5.2           |
+| Interface                                  | Description                                  | Supported Versions |
+| ------------------------------------------ | -------------------------------------------- | ------------------ |
+| [package:name](#packagename)               | Get the name of the package                  | >= 2.2.5           |
+| [package:get](#packageget)                 | Get the values of the package                | >= 2.1.6           |
+| [package:set](#packageset)                 | Set the values of the package                | >= 2.1.6           |
+| [package:add](#packageadd)                 | Add to the values of the package             | >= 2.2.5           |
+| [package:license](#packagelicense)         | Get the license of the package               | >= 2.3.9           |
+| [package:description](#packagedescription) | Get the description of the package           | >= 2.2.3           |
+| [package:plat](#packageplat)               | Get the platform of the package              | >= 2.2.2           |
+| [package:arch](#packagearch)               | Get the architecture of the package          | >= 2.2.2           |
+| [package:targetos](#packagetargetos)       | Get the targeted OS of the package           | >= 2.5.2           |
+| [package:targetarch](#packagetargetarch)   | Get the targeted architecture of the package | >= 2.5.2           |
 
 #### package:name
 
@@ -88,3 +89,7 @@ If the package is binary [`os.arch`](manual/builtin_modules.md#osarch) is return
 #### package:targetos
 
 - Get the targeted OS of the package. Can have the same values as [package:plat](#packageplat)
+
+#### package:targetarch
+
+- Get the targeted architecture of the package. Can have the same values as [package:arch](#packagearch)

--- a/manual/package_interface.md
+++ b/manual/package_interface.md
@@ -45,6 +45,7 @@ This page describes the interface for `package` of functions like `on_load()`, `
 | [package:addenv](#packageaddenv)               | Add the given values to the environment variable                             | >= 2.2.2           |
 | [package:versions](#packageversions)           | Get all version strings of the package                                       | >= 2.1.9           |
 | [package:version](#packageversion)             | Get the version of the package                                               | >= 2.1.6           |
+| [package:version_str](#packageversion_str)     | Get the version of the package as string                                     | >= 2.1.6           |
 
 #### package:name
 
@@ -410,3 +411,7 @@ version:minor()
 -- get the patch version
 version:patch()
 ```
+
+#### package:version_str
+
+- Get the version of the package as string

--- a/manual/package_interface.md
+++ b/manual/package_interface.md
@@ -1,65 +1,66 @@
 
 This page describes the interface for `package` of functions like `on_load()`, `on_install()` or `on_test()` of the [Package Dependencies](manual/package_dependencies.md)
 
-| Interface                                          | Description                                                                  | Supported Versions |
-| -------------------------------------------------- | ---------------------------------------------------------------------------- | ------------------ |
-| [package:name](#packagename)                       | Get the name of the package                                                  | >= 2.2.5           |
-| [package:get](#packageget)                         | Get the values of the package                                                | >= 2.1.6           |
-| [package:set](#packageset)                         | Set the values of the package                                                | >= 2.1.6           |
-| [package:add](#packageadd)                         | Add to the values of the package                                             | >= 2.2.5           |
-| [package:license](#packagelicense)                 | Get the license of the package                                               | >= 2.3.9           |
-| [package:description](#packagedescription)         | Get the description of the package                                           | >= 2.2.3           |
-| [package:plat](#packageplat)                       | Get the platform of the package                                              | >= 2.2.2           |
-| [package:arch](#packagearch)                       | Get the architecture of the package                                          | >= 2.2.2           |
-| [package:targetos](#packagetargetos)               | Get the targeted OS of the package                                           | >= 2.5.2           |
-| [package:targetarch](#packagetargetarch)           | Get the targeted architecture of the package                                 | >= 2.5.2           |
-| [package:mode](#packagemode)                       | Get the build mode of the package                                            | >= 2.2.5           |
-| [package:is_plat](#packageis_plat)                 | Wether the current platform is one of the given platforms                    | >= 2.2.6           |
-| [package:is_arch](#packageis_arch)                 | Wether the current architecture is one of the given platforms                | >= 2.2.6           |
-| [package:is_targetos](#packageis_targetos)         | Wether the currently targeted OS is one of the given OS                      | >= 2.5.2           |
-| [package:is_targetarch](#packageis_targetarch)     | Wether the currently targeted architecture is one of the given architectures | >= 2.5.2           |
-| [package:alias](#packagealias)                     | Get the alias of the package                                                 | >= 2.1.7           |
-| [package:urls](#packageurls)                       | Get the URLs of the package                                                  | >= 2.1.6           |
-| [package:urls_set](#packageurls_set)               | Set the URLs of the package                                                  | >= 2.1.6           |
-| [package:url_alias](#packageurl_alias)             | Get the alias of an URL                                                      | >= 2.1.6           |
-| [package:url_version](#packageurl_version)         | Get the version filter of an URL                                             | >= 2.1.6           |
-| [package:dep](#packagedep)                         | Get a dependency of the package                                              | >= 2.2.3           |
-| [package:deps](#packagedeps)                       | Get all dependencies of the package                                          | >= 2.1.7           |
-| [package:sourcehash](#packagesourcehash)           | Get the sha256 checksum of an URL alias                                      | >= 2.3.2           |
-| [package:kind](#packagekind)                       | Get the kind of the package                                                  | >= 2.1.7           |
-| [package:is_binary](#packageis_binary)             | Wether the package is of kind binary                                         | >= 2.5.2           |
-| [package:is_toolchain](#packageis_toolchain)       | Wether the package is of kind toolchain                                      | >= 2.5.2           |
-| [package:is_library](#packageis_library)           | Wether the package is of kind library                                        | >= 2.5.2           |
-| [package:is_toplevel](#packageis_toplevel)         | Wether the package is directly required by the user                          | >= 2.5.2           |
-| [package:is_thirdparty](#packageis_thirdparty)     | Wether the package is provided by a third party package manager              | >= 2.5.3           |
-| [package:is_debug](#packageis_debug)               | Wether the the package gets built with debug mode                            | >= 2.5.3           |
-| [package:is_supported](#packageis_supported)       | Wether the package is supported by the current platform and architecture     | >= 2.5.3           |
-| [package:debug](#packagedebug)                     | Wether the the package gets built with debug mode (deprecated)               | >= 2.2.3           |
-| [package:is_cross](#packageis_cross)               | Wether the package is getting cross-compiled                                 | >= 2.5.3           |
-| [package:cachedir](#packagecachedir)               | Get the cache directory of the package                                       | >= 2.1.6           |
-| [package:installdir](#packageinstalldir)           | Get the installation directory of the package                                | >= 2.2.2           |
-| [package:scriptdir](#packagescriptdir)             | Get the directory where the xmake.lua of the package lies                    | >= 2.2.5           |
-| [package:envs](#packageenvs)                       | Get the exported environment variables of the package                        | >= 2.2.5           |
-| [package:getenv](#packagegetenv)                   | Get the given environment variable                                           | >= 2.2.2           |
-| [package:setenv](#packagesetenv)                   | Set the given environment variable                                           | >= 2.2.2           |
-| [package:addenv](#packageaddenv)                   | Add the given values to the environment variable                             | >= 2.2.2           |
-| [package:versions](#packageversions)               | Get all version strings of the package                                       | >= 2.1.9           |
-| [package:version](#packageversion)                 | Get the version of the package                                               | >= 2.1.6           |
-| [package:version_str](#packageversion_str)         | Get the version of the package as string                                     | >= 2.1.6           |
-| [package:version_set](#packageversion_set)         | Set the version of the package                                               | >= 2.1.6           |
-| [package:config](#packageconfig)                   | Get the given configuration value of the package                             | >= 2.2.5           |
-| [package:config_set](#packageconfig_set)           | Set the given configuration value of the package                             | >= 2.5.1           |
-| [package:configs](#packageconfigs)                 | Get all configurations of the package                                        | >= 2.2.2           |
-| [package:buildhash](#packagebuildhash)             | Get the build hash of the package                                            | >= 2.2.5           |
-| [package:group](#packagegroup)                     | Get the group name of the package                                            | >= 2.2.3           |
-| [package:patches](#packagepatches)                 | Get all patches of the current version                                       | >= 2.2.5           |
-| [package:has_cfuncs](#packagehas_cfuncs)           | Wether the package has the given C functions                                 | >= 2.2.5           |
-| [package:has_cxxfuncs](#packagehas_cxxfuncs)       | Wether the package has the given C++ functions                               | >= 2.2.5           |
-| [package:has_ctypes](#packagehas_ctypes)           | Wether the package has the given C types                                     | >= 2.3.8           |
-| [package:has_cxxtypes](#packagehas_cxxtypes)       | Wether the package has the given C++ types                                   | >= 2.3.8           |
-| [package:has_cincludes](#packagehas_cincludes)     | Wether the package has the given C header files                              | >= 2.3.8           |
-| [package:has_cxxincludes](#packagehas_cxxincludes) | Wether the package has the given C++ header files                            | >= 2.3.8           |
-| [package:check_csnippets](#packagecheck_csnippets) | Wether the given C snippet can be compiled and linked                        | >= 2.2.6           |
+| Interface                                              | Description                                                                  | Supported Versions |
+| ------------------------------------------------------ | ---------------------------------------------------------------------------- | ------------------ |
+| [package:name](#packagename)                           | Get the name of the package                                                  | >= 2.2.5           |
+| [package:get](#packageget)                             | Get the values of the package                                                | >= 2.1.6           |
+| [package:set](#packageset)                             | Set the values of the package                                                | >= 2.1.6           |
+| [package:add](#packageadd)                             | Add to the values of the package                                             | >= 2.2.5           |
+| [package:license](#packagelicense)                     | Get the license of the package                                               | >= 2.3.9           |
+| [package:description](#packagedescription)             | Get the description of the package                                           | >= 2.2.3           |
+| [package:plat](#packageplat)                           | Get the platform of the package                                              | >= 2.2.2           |
+| [package:arch](#packagearch)                           | Get the architecture of the package                                          | >= 2.2.2           |
+| [package:targetos](#packagetargetos)                   | Get the targeted OS of the package                                           | >= 2.5.2           |
+| [package:targetarch](#packagetargetarch)               | Get the targeted architecture of the package                                 | >= 2.5.2           |
+| [package:mode](#packagemode)                           | Get the build mode of the package                                            | >= 2.2.5           |
+| [package:is_plat](#packageis_plat)                     | Wether the current platform is one of the given platforms                    | >= 2.2.6           |
+| [package:is_arch](#packageis_arch)                     | Wether the current architecture is one of the given platforms                | >= 2.2.6           |
+| [package:is_targetos](#packageis_targetos)             | Wether the currently targeted OS is one of the given OS                      | >= 2.5.2           |
+| [package:is_targetarch](#packageis_targetarch)         | Wether the currently targeted architecture is one of the given architectures | >= 2.5.2           |
+| [package:alias](#packagealias)                         | Get the alias of the package                                                 | >= 2.1.7           |
+| [package:urls](#packageurls)                           | Get the URLs of the package                                                  | >= 2.1.6           |
+| [package:urls_set](#packageurls_set)                   | Set the URLs of the package                                                  | >= 2.1.6           |
+| [package:url_alias](#packageurl_alias)                 | Get the alias of an URL                                                      | >= 2.1.6           |
+| [package:url_version](#packageurl_version)             | Get the version filter of an URL                                             | >= 2.1.6           |
+| [package:dep](#packagedep)                             | Get a dependency of the package                                              | >= 2.2.3           |
+| [package:deps](#packagedeps)                           | Get all dependencies of the package                                          | >= 2.1.7           |
+| [package:sourcehash](#packagesourcehash)               | Get the sha256 checksum of an URL alias                                      | >= 2.3.2           |
+| [package:kind](#packagekind)                           | Get the kind of the package                                                  | >= 2.1.7           |
+| [package:is_binary](#packageis_binary)                 | Wether the package is of kind binary                                         | >= 2.5.2           |
+| [package:is_toolchain](#packageis_toolchain)           | Wether the package is of kind toolchain                                      | >= 2.5.2           |
+| [package:is_library](#packageis_library)               | Wether the package is of kind library                                        | >= 2.5.2           |
+| [package:is_toplevel](#packageis_toplevel)             | Wether the package is directly required by the user                          | >= 2.5.2           |
+| [package:is_thirdparty](#packageis_thirdparty)         | Wether the package is provided by a third party package manager              | >= 2.5.3           |
+| [package:is_debug](#packageis_debug)                   | Wether the the package gets built with debug mode                            | >= 2.5.3           |
+| [package:is_supported](#packageis_supported)           | Wether the package is supported by the current platform and architecture     | >= 2.5.3           |
+| [package:debug](#packagedebug)                         | Wether the the package gets built with debug mode (deprecated)               | >= 2.2.3           |
+| [package:is_cross](#packageis_cross)                   | Wether the package is getting cross-compiled                                 | >= 2.5.3           |
+| [package:cachedir](#packagecachedir)                   | Get the cache directory of the package                                       | >= 2.1.6           |
+| [package:installdir](#packageinstalldir)               | Get the installation directory of the package                                | >= 2.2.2           |
+| [package:scriptdir](#packagescriptdir)                 | Get the directory where the xmake.lua of the package lies                    | >= 2.2.5           |
+| [package:envs](#packageenvs)                           | Get the exported environment variables of the package                        | >= 2.2.5           |
+| [package:getenv](#packagegetenv)                       | Get the given environment variable                                           | >= 2.2.2           |
+| [package:setenv](#packagesetenv)                       | Set the given environment variable                                           | >= 2.2.2           |
+| [package:addenv](#packageaddenv)                       | Add the given values to the environment variable                             | >= 2.2.2           |
+| [package:versions](#packageversions)                   | Get all version strings of the package                                       | >= 2.1.9           |
+| [package:version](#packageversion)                     | Get the version of the package                                               | >= 2.1.6           |
+| [package:version_str](#packageversion_str)             | Get the version of the package as string                                     | >= 2.1.6           |
+| [package:version_set](#packageversion_set)             | Set the version of the package                                               | >= 2.1.6           |
+| [package:config](#packageconfig)                       | Get the given configuration value of the package                             | >= 2.2.5           |
+| [package:config_set](#packageconfig_set)               | Set the given configuration value of the package                             | >= 2.5.1           |
+| [package:configs](#packageconfigs)                     | Get all configurations of the package                                        | >= 2.2.2           |
+| [package:buildhash](#packagebuildhash)                 | Get the build hash of the package                                            | >= 2.2.5           |
+| [package:group](#packagegroup)                         | Get the group name of the package                                            | >= 2.2.3           |
+| [package:patches](#packagepatches)                     | Get all patches of the current version                                       | >= 2.2.5           |
+| [package:has_cfuncs](#packagehas_cfuncs)               | Wether the package has the given C functions                                 | >= 2.2.5           |
+| [package:has_cxxfuncs](#packagehas_cxxfuncs)           | Wether the package has the given C++ functions                               | >= 2.2.5           |
+| [package:has_ctypes](#packagehas_ctypes)               | Wether the package has the given C types                                     | >= 2.3.8           |
+| [package:has_cxxtypes](#packagehas_cxxtypes)           | Wether the package has the given C++ types                                   | >= 2.3.8           |
+| [package:has_cincludes](#packagehas_cincludes)         | Wether the package has the given C header files                              | >= 2.3.8           |
+| [package:has_cxxincludes](#packagehas_cxxincludes)     | Wether the package has the given C++ header files                            | >= 2.3.8           |
+| [package:check_csnippets](#packagecheck_csnippets)     | Wether the given C snippet can be compiled and linked                        | >= 2.2.6           |
+| [package:check_cxxsnippets](#packagecheck_cxxsnippets) | Wether the given C++ snippet can be compiled and linked                      | >= 2.2.6           |
 
 #### package:name
 
@@ -601,5 +602,23 @@ on_test(function (package)
       printf("%s", bar.blob);
     }
   ]]}, {configs = {languages = "c99"}, includes = "foo.h"}))
+end)
+```
+
+#### package:check_cxxsnippets
+
+- Wether the given C++ snippet can be compiled and linked
+
+This should be used in `on_test` like so:
+```lua
+on_test(function (package)
+  assert(package:check_cxxsnippets({test = [[
+    #define USE_BLOB
+    #include <blob.hpp>
+    void test(int argc, char** argv) {
+      foo bar();
+      std::cout << bar.blob;
+    }
+  ]]}, {configs = {languages = "cxx11"}, includes = "foo.hpp"}))
 end)
 ```

--- a/manual/package_interface.md
+++ b/manual/package_interface.md
@@ -52,6 +52,7 @@ This page describes the interface for `package` of functions like `on_load()`, `
 | [package:configs](#packageconfigs)             | Get all configurations of the package                                        | >= 2.2.2           |
 | [package:buildhash](#packagebuildhash)         | Get the build hash of the package                                            | >= 2.2.5           |
 | [package:group](#packagegroup)                 | Get the group name of the package                                            | >= 2.2.3           |
+| [package:patches](#packagepatches)             | Get all patches of the current version                                       | >= 2.2.5           |
 
 #### package:name
 
@@ -478,3 +479,16 @@ local value_y = configs["value_y"]
 #### package:group
 
 - Get the group name of the package
+
+
+#### package:patches
+
+- Get all patches of the current version
+
+```lua
+-- returns a table with all patches
+local patches = package:patches()
+-- each element contains the keys "url" and "sha256"
+local url = patches[1]["url"]
+local sha256 = patches[1]["sha256"]
+```

--- a/manual/package_interface.md
+++ b/manual/package_interface.md
@@ -27,6 +27,9 @@ This page describes the interface for `package` of functions like `on_load()`, `
 | [package:deps](#packagedeps)                   | Get all dependencies of the package                                          | >= 2.1.7           |
 | [package:sourcehash](#packagesourcehash)       | Get the sha256 checksum of an URL alias                                      | >= 2.3.2           |
 | [package:kind](#packagekind)                   | Get the kind of the package                                                  | >= 2.1.7           |
+| [package:is_binary](#packageis_binary)         | Wether the package is of kind binary                                         | >= 2.5.2           |
+| [package:is_toolchain](#packageis_toolchain)   | Wether the package is of kind toolchain                                      | >= 2.5.2           |
+| [package:is_library](#packageis_library)       | Wether the package is of kind library                                        | >= 2.5.2           |
 
 #### package:name
 
@@ -273,3 +276,18 @@ package:sourcehash(package:url_alias(package:urls()[1]))
   + binary
   + toolchain (is also binary)
   + library (default)
+
+
+#### package:is_binary
+
+- Wether the package is of kind binary
+
+
+#### package:is_toolchain
+
+- Wether the package is of kind toolchain
+
+
+#### package:is_library
+
+- Wether the package is of kind library

--- a/manual/package_interface.md
+++ b/manual/package_interface.md
@@ -44,6 +44,7 @@ This page describes the interface for `package` of functions like `on_load()`, `
 | [package:setenv](#packagesetenv)               | Set the given environment variable                                           | >= 2.2.2           |
 | [package:addenv](#packageaddenv)               | Add the given values to the environment variable                             | >= 2.2.2           |
 | [package:versions](#packageversions)           | Get all version strings of the package                                       | >= 2.1.9           |
+| [package:version](#packageversion)             | Get the version of the package                                               | >= 2.1.6           |
 
 #### package:name
 
@@ -394,3 +395,18 @@ package:addenv("PATH", "bin", "lib")
 #### package:versions
 
 - Get all version strings of the package. Returns a table containing all versions as strings
+
+
+#### package:version
+
+- Get the version of the package
+
+```lua
+local version = package:version()
+-- get the major version
+version:major()
+-- get the minor version
+version:minor()
+-- get the patch version
+version:patch()
+```

--- a/manual/package_interface.md
+++ b/manual/package_interface.md
@@ -41,6 +41,7 @@ This page describes the interface for `package` of functions like `on_load()`, `
 | [package:scriptdir](#packagescriptdir)         | Get the directory where the xmake.lua of the package lies                    | >= 2.2.5           |
 | [package:envs](#packageenvs)                   | Get the exported environment variables of the package                        | >= 2.2.5           |
 | [package:getenv](#packagegetenv)               | Get the given environment variable                                           | >= 2.2.2           |
+| [package:setenv](#packagesetenv)               | Set the given environment variable                                           | >= 2.2.2           |
 
 #### package:name
 
@@ -368,4 +369,13 @@ package:installdir("include", "files")
 ```lua
 -- returns a table
 package:getenv("PATH")
+```
+
+#### package:setenv
+
+- Set the given environment variable. Overwrites the variable
+
+```lua
+-- sets PATH to {"bin", "lib"}
+package:setenv("PATH", "bin", "lib")
 ```

--- a/manual/package_interface.md
+++ b/manual/package_interface.md
@@ -49,6 +49,7 @@ This page describes the interface for `package` of functions like `on_load()`, `
 | [package:version_set](#packageversion_set)     | Set the version of the package                                               | >= 2.1.6           |
 | [package:config](#packageconfig)               | Get the given configuration value of the package                             | >= 2.2.5           |
 | [package:config_set](#packageconfig_set)       | Set the given configuration value of the package                             | >= 2.5.1           |
+| [package:configs](#packageconfigs)             | Get all configurations of the package                                        | >= 2.2.2           |
 
 #### package:name
 
@@ -454,4 +455,15 @@ package:config("value_y")
 ```lua
 package:config_set("enable_x", true)
 package:config_set("value_y", 6)
+```
+
+#### package:configs
+
+- Get all configurations of the package
+
+```lua
+-- returns a table with the configuration names as keys and their values as values
+local configs = package:configs()
+local enable_x = configs["enable_x"]
+local value_y = configs["value_y"]
 ```

--- a/manual/package_interface.md
+++ b/manual/package_interface.md
@@ -13,16 +13,12 @@ This page describes the interface for `package` of functions like `on_load()`, `
 | [package:arch](#packagearch)                           | Get the architecture of the package                                          | >= 2.2.2           |
 | [package:targetos](#packagetargetos)                   | Get the targeted OS of the package                                           | >= 2.5.2           |
 | [package:targetarch](#packagetargetarch)               | Get the targeted architecture of the package                                 | >= 2.5.2           |
-| [package:mode](#packagemode)                           | Get the build mode of the package                                            | >= 2.2.5           |
 | [package:is_plat](#packageis_plat)                     | Wether the current platform is one of the given platforms                    | >= 2.2.6           |
 | [package:is_arch](#packageis_arch)                     | Wether the current architecture is one of the given platforms                | >= 2.2.6           |
 | [package:is_targetos](#packageis_targetos)             | Wether the currently targeted OS is one of the given OS                      | >= 2.5.2           |
 | [package:is_targetarch](#packageis_targetarch)         | Wether the currently targeted architecture is one of the given architectures | >= 2.5.2           |
 | [package:alias](#packagealias)                         | Get the alias of the package                                                 | >= 2.1.7           |
 | [package:urls](#packageurls)                           | Get the URLs of the package                                                  | >= 2.1.6           |
-| [package:urls_set](#packageurls_set)                   | Set the URLs of the package                                                  | >= 2.1.6           |
-| [package:url_alias](#packageurl_alias)                 | Get the alias of an URL                                                      | >= 2.1.6           |
-| [package:url_version](#packageurl_version)             | Get the version filter of an URL                                             | >= 2.1.6           |
 | [package:dep](#packagedep)                             | Get a dependency of the package                                              | >= 2.2.3           |
 | [package:deps](#packagedeps)                           | Get all dependencies of the package                                          | >= 2.1.7           |
 | [package:sourcehash](#packagesourcehash)               | Get the sha256 checksum of an URL alias                                      | >= 2.3.2           |
@@ -46,12 +42,10 @@ This page describes the interface for `package` of functions like `on_load()`, `
 | [package:versions](#packageversions)                   | Get all version strings of the package                                       | >= 2.1.9           |
 | [package:version](#packageversion)                     | Get the version of the package                                               | >= 2.1.6           |
 | [package:version_str](#packageversion_str)             | Get the version of the package as string                                     | >= 2.1.6           |
-| [package:version_set](#packageversion_set)             | Set the version of the package                                               | >= 2.1.6           |
 | [package:config](#packageconfig)                       | Get the given configuration value of the package                             | >= 2.2.5           |
 | [package:config_set](#packageconfig_set)               | Set the given configuration value of the package                             | >= 2.5.1           |
 | [package:configs](#packageconfigs)                     | Get all configurations of the package                                        | >= 2.2.2           |
 | [package:buildhash](#packagebuildhash)                 | Get the build hash of the package                                            | >= 2.2.5           |
-| [package:group](#packagegroup)                         | Get the group name of the package                                            | >= 2.2.3           |
 | [package:patches](#packagepatches)                     | Get all patches of the current version                                       | >= 2.2.5           |
 | [package:has_cfuncs](#packagehas_cfuncs)               | Wether the package has the given C functions                                 | >= 2.2.5           |
 | [package:has_cxxfuncs](#packagehas_cxxfuncs)           | Wether the package has the given C++ functions                               | >= 2.2.5           |
@@ -142,11 +136,6 @@ If the package is binary [`os.arch`](manual/builtin_modules.md#osarch) is return
 
 - Get the targeted architecture of the package. Can have the same values as [package:arch](#packagearch)
 
-#### package:mode
-
-- Get the build mode. Can be any of:
-  + debug
-  + release
 
 #### package:is_plat
 
@@ -220,47 +209,6 @@ Then write this:
 ```lua
 -- returns the table {"https://example.com/library-$(version).zip"}
 package:urls()
-```
-
-#### package:urls_set
-
-- Set the URLs of the package. Overwrites all URLs of the package.
-
-```lua
-package:urls_set({"https://example.com/library-$(version).zip"})
-```
-
-#### package:url_alias
-
-- Get the alias of an URL
-
-If the alias is set like so:
-```lua
-add_urls("https://example.com/library-$(version).zip", {alias = example})
-```
-It can be retrieved like so:
-```lua
--- both return "example"
--- the URL needs to be provided
-package:url_alias("https://example.com/library-$(version).zip")
--- this is also possible
-package:url_alias(package:urls()[1])
-```
-
-#### package:url_version
-
-- Returns the version filter of the given URL
-
-This returns the function provided by `version`:
-```lua
-add_urls("https://example.com/library-$(version).zip", {version = function (version) return "example_version" end})
-```
-It can be used like so:
-```lua
--- the URL needs to be provided
-local version_func = package:url_version(package:urls()[1])
--- returns "example_version"
-version_func()
 ```
 
 #### package:dep
@@ -432,19 +380,6 @@ version:patch()
 - Get the version of the package as string
 
 
-#### package:version_set
-
-- Set the version of the package
-
-```lua
--- normal semantic version
-package:version_set("2.4.1", "versions")
--- branch for git repo
-package:version_set("dev", "branches")
--- tag of git repo
-package:version_set("v2.4.1", "tags")
-```
-
 #### package:config
 
 - Get the given configuration value of the package
@@ -482,11 +417,6 @@ local value_y = configs["value_y"]
 #### package:buildhash
 
 - Get the build hash of the package
-
-
-#### package:group
-
-- Get the group name of the package
 
 
 #### package:patches

--- a/manual/package_interface.md
+++ b/manual/package_interface.md
@@ -36,6 +36,7 @@ This page describes the interface for `package` of functions like `on_load()`, `
 | [package:is_supported](#packageis_supported)   | Wether the package is supported by the current platform and architecture     | >= 2.5.3           |
 | [package:debug](#packagedebug)                 | Wether the the package gets built with debug mode (deprecated)               | >= 2.2.3           |
 | [package:is_cross](#packageis_cross)           | Wether the package is getting cross-compiled                                 | >= 2.5.3           |
+| [package:cachedir](#packagecachedir)           | Get the cache directory of the package                                       | >= 2.1.6           |
 
 #### package:name
 
@@ -326,3 +327,8 @@ package:sourcehash(package:url_alias(package:urls()[1]))
 #### package:is_cross
 
 - Wether the package is getting cross-compiled
+
+
+#### package:cachedir
+
+- Get the cache directory of the package

--- a/manual/package_interface.md
+++ b/manual/package_interface.md
@@ -1,0 +1,1 @@
+# Package Interface

--- a/manual/package_interface.md
+++ b/manual/package_interface.md
@@ -51,6 +51,7 @@ This page describes the interface for `package` of functions like `on_load()`, `
 | [package:config_set](#packageconfig_set)       | Set the given configuration value of the package                             | >= 2.5.1           |
 | [package:configs](#packageconfigs)             | Get all configurations of the package                                        | >= 2.2.2           |
 | [package:buildhash](#packagebuildhash)         | Get the build hash of the package                                            | >= 2.2.5           |
+| [package:group](#packagegroup)                 | Get the group name of the package                                            | >= 2.2.3           |
 
 #### package:name
 
@@ -472,3 +473,8 @@ local value_y = configs["value_y"]
 #### package:buildhash
 
 - Get the build hash of the package
+
+
+#### package:group
+
+- Get the group name of the package

--- a/manual/package_interface.md
+++ b/manual/package_interface.md
@@ -47,6 +47,7 @@ This page describes the interface for `package` of functions like `on_load()`, `
 | [package:version](#packageversion)             | Get the version of the package                                               | >= 2.1.6           |
 | [package:version_str](#packageversion_str)     | Get the version of the package as string                                     | >= 2.1.6           |
 | [package:version_set](#packageversion_set)     | Set the version of the package                                               | >= 2.1.6           |
+| [package:config](#packageconfig)               | Get the given configuration value of the package                             | >= 2.2.5           |
 
 #### package:name
 
@@ -429,4 +430,18 @@ package:version_set("2.4.1", "versions")
 package:version_set("dev", "branches")
 -- tag of git repo
 package:version_set("v2.4.1", "tags")
+```
+
+#### package:config
+
+- Get the given configuration value of the package
+
+```lua
+-- if configurations are set like so
+add_require("example", {config = {enable_x = true, value_y = 6}})
+-- these values can be retrieved like so
+-- returns true
+package:config("enable_x")
+-- returns 6
+package:config("value_y")
 ```

--- a/manual/package_interface.md
+++ b/manual/package_interface.md
@@ -55,6 +55,7 @@ This page describes the interface for `package` of functions like `on_load()`, `
 | [package:patches](#packagepatches)             | Get all patches of the current version                                       | >= 2.2.5           |
 | [package:has_cfuncs](#packagehas_cfuncs)       | Wether the package has the given C functions                                 | >= 2.2.5           |
 | [package:has_cxxfuncs](#packagehas_cxxfuncs)   | Wether the package has the given C++ functions                               | >= 2.2.5           |
+| [package:has_ctypes](#packagehas_ctypes)       | Wether the package has the given C types                                     | >= 2.3.8           |
 
 #### package:name
 
@@ -524,5 +525,21 @@ on_test(function (package)
   assert(package:has_cxxfuncs("blob", {includes = "blob.hpp", configs = {defines = "USE_BLOB"}}))
   -- you can even set the language
   assert(package:has_cxxfuncs("bla", {configs = {languages = "cxx17"}}))
+end)
+```
+
+#### package:has_ctypes
+
+- Wether the package has the given C types
+
+This should be used inside `on_test` like so:
+```lua
+on_test(function (package)
+  assert(package:has_ctypes("foo"))
+  -- you can also add configs
+  assert(package:has_ctypes("bar", {includes = "foo_bar.h"}))
+  assert(package:has_ctypes("blob", {includes = "blob.h", configs = {defines = "USE_BLOB"}}))
+  -- you can even set the language
+  assert(package:has_ctypes("bla", {configs = {languages = "c99"}}))
 end)
 ```

--- a/manual/package_interface.md
+++ b/manual/package_interface.md
@@ -13,6 +13,7 @@ This page describes the interface for `package` of functions like `on_load()`, `
 | [package:arch](#packagearch)               | Get the architecture of the package          | >= 2.2.2           |
 | [package:targetos](#packagetargetos)       | Get the targeted OS of the package           | >= 2.5.2           |
 | [package:targetarch](#packagetargetarch)   | Get the targeted architecture of the package | >= 2.5.2           |
+| [package:mode](#packagemode)               | Get the build mode of the package            | >= 2.2.5           |
 
 #### package:name
 
@@ -93,3 +94,9 @@ If the package is binary [`os.arch`](manual/builtin_modules.md#osarch) is return
 #### package:targetarch
 
 - Get the targeted architecture of the package. Can have the same values as [package:arch](#packagearch)
+
+#### package:mode
+
+- Get the build mode. Can be any of:
+  + debug
+  + release

--- a/manual/package_interface.md
+++ b/manual/package_interface.md
@@ -1,19 +1,20 @@
 
 This page describes the interface for `package` of functions like `on_load()`, `on_install()` or `on_test()` of the [Package Dependencies](manual/package_dependencies.md)
 
-| Interface                                  | Description                                  | Supported Versions |
-| ------------------------------------------ | -------------------------------------------- | ------------------ |
-| [package:name](#packagename)               | Get the name of the package                  | >= 2.2.5           |
-| [package:get](#packageget)                 | Get the values of the package                | >= 2.1.6           |
-| [package:set](#packageset)                 | Set the values of the package                | >= 2.1.6           |
-| [package:add](#packageadd)                 | Add to the values of the package             | >= 2.2.5           |
-| [package:license](#packagelicense)         | Get the license of the package               | >= 2.3.9           |
-| [package:description](#packagedescription) | Get the description of the package           | >= 2.2.3           |
-| [package:plat](#packageplat)               | Get the platform of the package              | >= 2.2.2           |
-| [package:arch](#packagearch)               | Get the architecture of the package          | >= 2.2.2           |
-| [package:targetos](#packagetargetos)       | Get the targeted OS of the package           | >= 2.5.2           |
-| [package:targetarch](#packagetargetarch)   | Get the targeted architecture of the package | >= 2.5.2           |
-| [package:mode](#packagemode)               | Get the build mode of the package            | >= 2.2.5           |
+| Interface                                  | Description                                               | Supported Versions |
+| ------------------------------------------ | --------------------------------------------------------- | ------------------ |
+| [package:name](#packagename)               | Get the name of the package                               | >= 2.2.5           |
+| [package:get](#packageget)                 | Get the values of the package                             | >= 2.1.6           |
+| [package:set](#packageset)                 | Set the values of the package                             | >= 2.1.6           |
+| [package:add](#packageadd)                 | Add to the values of the package                          | >= 2.2.5           |
+| [package:license](#packagelicense)         | Get the license of the package                            | >= 2.3.9           |
+| [package:description](#packagedescription) | Get the description of the package                        | >= 2.2.3           |
+| [package:plat](#packageplat)               | Get the platform of the package                           | >= 2.2.2           |
+| [package:arch](#packagearch)               | Get the architecture of the package                       | >= 2.2.2           |
+| [package:targetos](#packagetargetos)       | Get the targeted OS of the package                        | >= 2.5.2           |
+| [package:targetarch](#packagetargetarch)   | Get the targeted architecture of the package              | >= 2.5.2           |
+| [package:mode](#packagemode)               | Get the build mode of the package                         | >= 2.2.5           |
+| [package:is_plat](#packageis_plat)         | Wether the current platform is one of the given platforms | >= 2.2.6           |
 
 #### package:name
 
@@ -100,3 +101,14 @@ If the package is binary [`os.arch`](manual/builtin_modules.md#osarch) is return
 - Get the build mode. Can be any of:
   + debug
   + release
+
+#### package:is_plat
+
+- Wether the current platform is one of the given platforms
+
+```lua
+-- Is the current platform android?
+package:is_plat("android")
+-- Is the current platform windows, linux or macosx?
+package:is_plat("windows", "linux", "macosx")
+```

--- a/manual/package_interface.md
+++ b/manual/package_interface.md
@@ -39,6 +39,7 @@ This page describes the interface for `package` of functions like `on_load()`, `
 | [package:cachedir](#packagecachedir)           | Get the cache directory of the package                                       | >= 2.1.6           |
 | [package:installdir](#packageinstalldir)       | Get the installation directory of the package                                | >= 2.2.2           |
 | [package:scriptdir](#packagescriptdir)         | Get the directory where the xmake.lua of the package lies                    | >= 2.2.5           |
+| [package:envs](#packageenvs)                   | Get the exported environment variables of the package                        | >= 2.2.5           |
 
 #### package:name
 
@@ -352,3 +353,8 @@ package:installdir("include", "files")
 #### package:scriptdir
 
 - Get the directory where the xmake.lua of the package lies
+
+
+#### package:envs
+
+- Get the exported environment variables of the package

--- a/manual/package_interface.md
+++ b/manual/package_interface.md
@@ -57,6 +57,7 @@ This page describes the interface for `package` of functions like `on_load()`, `
 | [package:has_cxxfuncs](#packagehas_cxxfuncs)   | Wether the package has the given C++ functions                               | >= 2.2.5           |
 | [package:has_ctypes](#packagehas_ctypes)       | Wether the package has the given C types                                     | >= 2.3.8           |
 | [package:has_cxxtypes](#packagehas_cxxtypes)   | Wether the package has the given C++ types                                   | >= 2.3.8           |
+| [package:has_cincludes](#packagehas_cincludes) | Wether the package has the given C header files                              | >= 2.3.8           |
 
 #### package:name
 
@@ -558,5 +559,16 @@ on_test(function (package)
   assert(package:has_cxxtypes("blob", {includes = "blob.hpp", configs = {defines = "USE_BLOB"}}))
   -- you can even set the language
   assert(package:has_cxxtypes("bla", {configs = {languages = "cxx17"}}))
+end)
+```
+
+#### package:has_cincludes
+
+- Wether the package has the given C header files
+
+This should be used in `on_test` like so:
+```lua
+on_test(function (package)
+  assert(package:has_cincludes("foo.h"))
 end)
 ```

--- a/manual/package_interface.md
+++ b/manual/package_interface.md
@@ -22,6 +22,8 @@ This page describes the interface for `package` of functions like `on_load()`, `
 | [package:urls](#packageurls)                   | Get the URLs of the package                                                  | >= 2.1.6           |
 | [package:urls_set](#packageurls_set)           | Set the URLs of the package                                                  | >= 2.1.6           |
 | [package:url_alias](#packageurl_alias)         | Get the alias of an URL                                                      | >= 2.1.6           |
+| [package:url_version](#packageurl_version)     | Get the version filter of an URL                                             | >= 2.1.6           |
+
 #### package:name
 
 - Get the name of the package
@@ -205,4 +207,20 @@ It can be retrieved like so:
 package:url_alias("https://example.com/library-$(version).zip")
 -- this is also possible
 package:url_alias(package:urls()[1])
+```
+
+#### package:url_version
+
+- Returns the version filter of the given URL
+
+This returns the function provided by `version`:
+```lua
+add_urls("https://example.com/library-$(version).zip", {version = function (version) return "example_version" end})
+```
+It can be used like so:
+```lua
+-- the URL needs to be provided
+local version_func = package:url_version(package:urls()[1])
+-- returns "example_version"
+version_func()
 ```

--- a/manual/package_interface.md
+++ b/manual/package_interface.md
@@ -18,6 +18,7 @@ This page describes the interface for `package` of functions like `on_load()`, `
 | [package:is_arch](#packageis_arch)             | Wether the current architecture is one of the given platforms                | >= 2.2.6           |
 | [package:is_targetos](#packageis_targetos)     | Wether the currently targeted OS is one of the given OS                      | >= 2.5.2           |
 | [package:is_targetarch](#packageis_targetarch) | Wether the currently targeted architecture is one of the given architectures | >= 2.5.2           |
+| [package:alias](#packagealias)                 | Get the alias of the package                                                 | >= 2.1.7           |
 
 #### package:name
 
@@ -147,4 +148,18 @@ package:is_targetos("android", "iphoneos")
 package:is_targetarch("x86")
 -- Is the currently targeted architecture x64 or x86_64
 package:is_targetarch("x64", "x86_64")
+```
+
+#### package:alias
+
+- Get the alias of the package
+
+If the user sets an alias like so:
+```lua
+add_requires("libsdl", {alias = "sdl"})
+```
+This alias can be retrieved by
+```lua
+-- returns "sdl"
+package:alias()
 ```

--- a/manual/package_interface.md
+++ b/manual/package_interface.md
@@ -40,6 +40,7 @@ This page describes the interface for `package` of functions like `on_load()`, `
 | [package:installdir](#packageinstalldir)       | Get the installation directory of the package                                | >= 2.2.2           |
 | [package:scriptdir](#packagescriptdir)         | Get the directory where the xmake.lua of the package lies                    | >= 2.2.5           |
 | [package:envs](#packageenvs)                   | Get the exported environment variables of the package                        | >= 2.2.5           |
+| [package:getenv](#packagegetenv)               | Get the given environment variable                                           | >= 2.2.2           |
 
 #### package:name
 
@@ -358,3 +359,13 @@ package:installdir("include", "files")
 #### package:envs
 
 - Get the exported environment variables of the package
+
+
+#### package:getenv
+
+- Get the given environment variable
+
+```lua
+-- returns a table
+package:getenv("PATH")
+```

--- a/manual/package_interface.md
+++ b/manual/package_interface.md
@@ -20,6 +20,7 @@ This page describes the interface for `package` of functions like `on_load()`, `
 | [package:is_targetarch](#packageis_targetarch) | Wether the currently targeted architecture is one of the given architectures | >= 2.5.2           |
 | [package:alias](#packagealias)                 | Get the alias of the package                                                 | >= 2.1.7           |
 | [package:urls](#packageurls)                   | Get the URLs of the package                                                  | >= 2.1.6           |
+| [package:urls_set](#packageurls_set)           | Set the URLs of the package                                                  | >= 2.1.6           |
 
 #### package:name
 
@@ -180,3 +181,12 @@ Then write this:
 -- returns the table {"https://example.com/library-$(version).zip"}
 package:urls()
 ```
+
+#### package:urls_set
+
+- Set the URLs of the package. Overwrites all URLs of the package.
+
+```lua
+package:urls_set({"https://example.com/library-$(version).zip"})
+```
+

--- a/manual/package_interface.md
+++ b/manual/package_interface.md
@@ -1,20 +1,21 @@
 
 This page describes the interface for `package` of functions like `on_load()`, `on_install()` or `on_test()` of the [Package Dependencies](manual/package_dependencies.md)
 
-| Interface                                  | Description                                               | Supported Versions |
-| ------------------------------------------ | --------------------------------------------------------- | ------------------ |
-| [package:name](#packagename)               | Get the name of the package                               | >= 2.2.5           |
-| [package:get](#packageget)                 | Get the values of the package                             | >= 2.1.6           |
-| [package:set](#packageset)                 | Set the values of the package                             | >= 2.1.6           |
-| [package:add](#packageadd)                 | Add to the values of the package                          | >= 2.2.5           |
-| [package:license](#packagelicense)         | Get the license of the package                            | >= 2.3.9           |
-| [package:description](#packagedescription) | Get the description of the package                        | >= 2.2.3           |
-| [package:plat](#packageplat)               | Get the platform of the package                           | >= 2.2.2           |
-| [package:arch](#packagearch)               | Get the architecture of the package                       | >= 2.2.2           |
-| [package:targetos](#packagetargetos)       | Get the targeted OS of the package                        | >= 2.5.2           |
-| [package:targetarch](#packagetargetarch)   | Get the targeted architecture of the package              | >= 2.5.2           |
-| [package:mode](#packagemode)               | Get the build mode of the package                         | >= 2.2.5           |
-| [package:is_plat](#packageis_plat)         | Wether the current platform is one of the given platforms | >= 2.2.6           |
+| Interface                                  | Description                                                   | Supported Versions |
+| ------------------------------------------ | ------------------------------------------------------------- | ------------------ |
+| [package:name](#packagename)               | Get the name of the package                                   | >= 2.2.5           |
+| [package:get](#packageget)                 | Get the values of the package                                 | >= 2.1.6           |
+| [package:set](#packageset)                 | Set the values of the package                                 | >= 2.1.6           |
+| [package:add](#packageadd)                 | Add to the values of the package                              | >= 2.2.5           |
+| [package:license](#packagelicense)         | Get the license of the package                                | >= 2.3.9           |
+| [package:description](#packagedescription) | Get the description of the package                            | >= 2.2.3           |
+| [package:plat](#packageplat)               | Get the platform of the package                               | >= 2.2.2           |
+| [package:arch](#packagearch)               | Get the architecture of the package                           | >= 2.2.2           |
+| [package:targetos](#packagetargetos)       | Get the targeted OS of the package                            | >= 2.5.2           |
+| [package:targetarch](#packagetargetarch)   | Get the targeted architecture of the package                  | >= 2.5.2           |
+| [package:mode](#packagemode)               | Get the build mode of the package                             | >= 2.2.5           |
+| [package:is_plat](#packageis_plat)         | Wether the current platform is one of the given platforms     | >= 2.2.6           |
+| [package:is_arch](#packageis_arch)         | Wether the current architecture is one of the given platforms | >= 2.2.6           |
 
 #### package:name
 
@@ -111,4 +112,15 @@ If the package is binary [`os.arch`](manual/builtin_modules.md#osarch) is return
 package:is_plat("android")
 -- Is the current platform windows, linux or macosx?
 package:is_plat("windows", "linux", "macosx")
+```
+
+#### package:is_arch
+
+- Wether the current platform is one of the given platforms
+
+```lua
+-- Is the current architecture x86
+package:is_arch("x86")
+-- Is the current architecture x64 or x86_64
+package:is_arch("x64", "x86_64")
 ```

--- a/manual/package_interface.md
+++ b/manual/package_interface.md
@@ -34,6 +34,7 @@ This page describes the interface for `package` of functions like `on_load()`, `
 | [package:is_thirdparty](#packageis_thirdparty) | Wether the package is provided by a third party package manager              | >= 2.5.3           |
 | [package:is_debug](#packageis_debug)           | Wether the the package gets built with debug mode                            | >= 2.5.3           |
 | [package:is_supported](#packageis_supported)   | Wether the package is supported by the current platform and architecture     | >= 2.5.3           |
+| [package:debug](#packagedebug)                 | Wether the the package gets built with debug mode (deprecated)               | >= 2.2.3           |
 
 #### package:name
 
@@ -314,3 +315,8 @@ package:sourcehash(package:url_alias(package:urls()[1]))
 #### package:is_supported
 
 - Wether the package is supported by the current platform and architecture
+
+
+#### package:debug
+
+- Wether the the package gets built with debug mode (deprecated: use [`package:is_debug`](#packageis_debug) instead)

--- a/manual/package_interface.md
+++ b/manual/package_interface.md
@@ -33,6 +33,7 @@ This page describes the interface for `package` of functions like `on_load()`, `
 | [package:is_toplevel](#packageis_toplevel)     | Wether the package is directly required by the user                          | >= 2.5.2           |
 | [package:is_thirdparty](#packageis_thirdparty) | Wether the package is provided by a third party package manager              | >= 2.5.3           |
 | [package:is_debug](#packageis_debug)           | Wether the the package gets built with debug mode                            | >= 2.5.3           |
+| [package:is_supported](#packageis_supported)   | Wether the package is supported by the current platform and architecture     | >= 2.5.3           |
 
 #### package:name
 
@@ -308,3 +309,8 @@ package:sourcehash(package:url_alias(package:urls()[1]))
 #### package:is_debug
 
 - Wether the package is build with debug mode (Same as `package:config("debug")`)
+
+
+#### package:is_supported
+
+- Wether the package is supported by the current platform and architecture

--- a/manual/package_interface.md
+++ b/manual/package_interface.md
@@ -42,6 +42,7 @@ This page describes the interface for `package` of functions like `on_load()`, `
 | [package:envs](#packageenvs)                   | Get the exported environment variables of the package                        | >= 2.2.5           |
 | [package:getenv](#packagegetenv)               | Get the given environment variable                                           | >= 2.2.2           |
 | [package:setenv](#packagesetenv)               | Set the given environment variable                                           | >= 2.2.2           |
+| [package:addenv](#packageaddenv)               | Add the given values to the environment variable                             | >= 2.2.2           |
 
 #### package:name
 
@@ -378,4 +379,13 @@ package:getenv("PATH")
 ```lua
 -- sets PATH to {"bin", "lib"}
 package:setenv("PATH", "bin", "lib")
+```
+
+#### package:addenv
+
+- Add the given values to the environment variable
+
+```lua
+-- adds "bin" and "lib" to PATH
+package:addenv("PATH", "bin", "lib")
 ```

--- a/manual/package_interface.md
+++ b/manual/package_interface.md
@@ -1,22 +1,23 @@
 
 This page describes the interface for `package` of functions like `on_load()`, `on_install()` or `on_test()` of the [Package Dependencies](manual/package_dependencies.md)
 
-| Interface                                  | Description                                                   | Supported Versions |
-| ------------------------------------------ | ------------------------------------------------------------- | ------------------ |
-| [package:name](#packagename)               | Get the name of the package                                   | >= 2.2.5           |
-| [package:get](#packageget)                 | Get the values of the package                                 | >= 2.1.6           |
-| [package:set](#packageset)                 | Set the values of the package                                 | >= 2.1.6           |
-| [package:add](#packageadd)                 | Add to the values of the package                              | >= 2.2.5           |
-| [package:license](#packagelicense)         | Get the license of the package                                | >= 2.3.9           |
-| [package:description](#packagedescription) | Get the description of the package                            | >= 2.2.3           |
-| [package:plat](#packageplat)               | Get the platform of the package                               | >= 2.2.2           |
-| [package:arch](#packagearch)               | Get the architecture of the package                           | >= 2.2.2           |
-| [package:targetos](#packagetargetos)       | Get the targeted OS of the package                            | >= 2.5.2           |
-| [package:targetarch](#packagetargetarch)   | Get the targeted architecture of the package                  | >= 2.5.2           |
-| [package:mode](#packagemode)               | Get the build mode of the package                             | >= 2.2.5           |
-| [package:is_plat](#packageis_plat)         | Wether the current platform is one of the given platforms     | >= 2.2.6           |
-| [package:is_arch](#packageis_arch)         | Wether the current architecture is one of the given platforms | >= 2.2.6           |
-| [package:is_targetos](#packageis_targetos) | Wether the currently targeted OS is one of the given OS       | >= 2.5.2           |
+| Interface                                      | Description                                                                  | Supported Versions |
+| ---------------------------------------------- | ---------------------------------------------------------------------------- | ------------------ |
+| [package:name](#packagename)                   | Get the name of the package                                                  | >= 2.2.5           |
+| [package:get](#packageget)                     | Get the values of the package                                                | >= 2.1.6           |
+| [package:set](#packageset)                     | Set the values of the package                                                | >= 2.1.6           |
+| [package:add](#packageadd)                     | Add to the values of the package                                             | >= 2.2.5           |
+| [package:license](#packagelicense)             | Get the license of the package                                               | >= 2.3.9           |
+| [package:description](#packagedescription)     | Get the description of the package                                           | >= 2.2.3           |
+| [package:plat](#packageplat)                   | Get the platform of the package                                              | >= 2.2.2           |
+| [package:arch](#packagearch)                   | Get the architecture of the package                                          | >= 2.2.2           |
+| [package:targetos](#packagetargetos)           | Get the targeted OS of the package                                           | >= 2.5.2           |
+| [package:targetarch](#packagetargetarch)       | Get the targeted architecture of the package                                 | >= 2.5.2           |
+| [package:mode](#packagemode)                   | Get the build mode of the package                                            | >= 2.2.5           |
+| [package:is_plat](#packageis_plat)             | Wether the current platform is one of the given platforms                    | >= 2.2.6           |
+| [package:is_arch](#packageis_arch)             | Wether the current architecture is one of the given platforms                | >= 2.2.6           |
+| [package:is_targetos](#packageis_targetos)     | Wether the currently targeted OS is one of the given OS                      | >= 2.5.2           |
+| [package:is_targetarch](#packageis_targetarch) | Wether the currently targeted architecture is one of the given architectures | >= 2.5.2           |
 
 #### package:name
 
@@ -135,4 +136,15 @@ package:is_arch("x64", "x86_64")
 package:is_targetos("windows")
 -- Is the currently targeted OS android or iphoneos?
 package:is_targetos("android", "iphoneos")
+```
+
+#### package:is_targetarch
+
+- Wether the currently targeted architecture is one of the given architectures
+
+```lua
+-- Is the currently targeted architecture x86
+package:is_targetarch("x86")
+-- Is the currently targeted architecture x64 or x86_64
+package:is_targetarch("x64", "x86_64")
 ```

--- a/manual/package_interface.md
+++ b/manual/package_interface.md
@@ -11,6 +11,7 @@ This page describes the interface for `package` of functions like `on_load()`, `
 | [package:description](#packagedescription) | Get the description of the package  | >= 2.2.3           |
 | [package:plat](#packageplat)               | Get the platform of the package     | >= 2.2.2           |
 | [package:arch](#packagearch)               | Get the architecture of the package | >= 2.2.2           |
+| [package:targetos](#packagetargetos)       | Get the targeted OS of the package  | >= 2.5.2           |
 
 #### package:name
 
@@ -83,3 +84,7 @@ If the package is binary [`os.host`](manual/builtin_modules.md#oshost) is return
 - Get the architecture of the package (e.g. x86, x64, x86_64)
 
 If the package is binary [`os.arch`](manual/builtin_modules.md#osarch) is returned
+
+#### package:targetos
+
+- Get the targeted OS of the package. Can have the same values as [package:plat](#packageplat)

--- a/manual/package_interface.md
+++ b/manual/package_interface.md
@@ -37,6 +37,7 @@ This page describes the interface for `package` of functions like `on_load()`, `
 | [package:debug](#packagedebug)                 | Wether the the package gets built with debug mode (deprecated)               | >= 2.2.3           |
 | [package:is_cross](#packageis_cross)           | Wether the package is getting cross-compiled                                 | >= 2.5.3           |
 | [package:cachedir](#packagecachedir)           | Get the cache directory of the package                                       | >= 2.1.6           |
+| [package:installdir](#packageinstalldir)       | Get the installation directory of the package                                | >= 2.2.2           |
 
 #### package:name
 
@@ -332,3 +333,17 @@ package:sourcehash(package:url_alias(package:urls()[1]))
 #### package:cachedir
 
 - Get the cache directory of the package
+
+
+#### package:installdir
+
+- Get the installation directory of the package. Can also be used to get a subdirectory. If the given directory tree does not exist it will be created.
+
+```lua
+-- returns the installation directory
+package:installdir()
+-- returns the subdirectory include inside the installation directory
+package:installdir("include")
+-- returns the subdirectory include/files
+package:installdir("include", "files")
+```

--- a/manual/package_interface.md
+++ b/manual/package_interface.md
@@ -32,6 +32,7 @@ This page describes the interface for `package` of functions like `on_load()`, `
 | [package:is_library](#packageis_library)       | Wether the package is of kind library                                        | >= 2.5.2           |
 | [package:is_toplevel](#packageis_toplevel)     | Wether the package is directly required by the user                          | >= 2.5.2           |
 | [package:is_thirdparty](#packageis_thirdparty) | Wether the package is provided by a third party package manager              | >= 2.5.3           |
+| [package:is_debug](#packageis_debug)           | Wether the the package gets built with debug mode                            | >= 2.5.3           |
 
 #### package:name
 
@@ -302,3 +303,8 @@ package:sourcehash(package:url_alias(package:urls()[1]))
 #### package:is_thirdparty
 
 - Wether the package is provided by a thirdparty package manager (e.g. brew, conan, vcpkg)
+
+
+#### package:is_debug
+
+- Wether the package is build with debug mode (Same as `package:config("debug")`)

--- a/manual/package_interface.md
+++ b/manual/package_interface.md
@@ -21,7 +21,7 @@ This page describes the interface for `package` of functions like `on_load()`, `
 | [package:alias](#packagealias)                 | Get the alias of the package                                                 | >= 2.1.7           |
 | [package:urls](#packageurls)                   | Get the URLs of the package                                                  | >= 2.1.6           |
 | [package:urls_set](#packageurls_set)           | Set the URLs of the package                                                  | >= 2.1.6           |
-
+| [package:url_alias](#packageurl_alias)         | Get the alias of an URL                                                      | >= 2.1.6           |
 #### package:name
 
 - Get the name of the package
@@ -190,3 +190,19 @@ package:urls()
 package:urls_set({"https://example.com/library-$(version).zip"})
 ```
 
+#### package:url_alias
+
+- Get the alias of an URL
+
+If the alias is set like so:
+```lua
+add_urls("https://example.com/library-$(version).zip", {alias = example})
+```
+It can be retrieved like so:
+```lua
+-- both return "example"
+-- the URL needs to be provided
+package:url_alias("https://example.com/library-$(version).zip")
+-- this is also possible
+package:url_alias(package:urls()[1])
+```

--- a/manual/package_interface.md
+++ b/manual/package_interface.md
@@ -5,6 +5,7 @@ This page describes the interface for `package` of functions like `on_load()`, `
 | ---------------------------- | ----------------------------- | ------------------ |
 | [package:name](#packagename) | Get the name of the package   | >= 2.2.5           |
 | [package:get](#packageget)   | Get the values of the package | >= 2.1.6           |
+| [package:set](#packageset)   | Set the values of the package | >= 2.1.6           |
 
 #### package:name
 
@@ -21,4 +22,17 @@ package:get("deps")
 package:get("links")
 -- get the defined macros
 package:get("defines")
+```
+
+#### package:set
+
+- Set the values of the package by name (If you just want to add values use [package:add](#packageadd))
+
+```lua
+-- set the dependencies
+package:set("deps", {"python"})
+-- set the links
+package:set("links", {"sdl2"})
+-- set the defined macros
+package:set("defines", {"SDL_MAIN_HANDLED"})
 ```

--- a/manual/package_interface.md
+++ b/manual/package_interface.md
@@ -53,6 +53,7 @@ This page describes the interface for `package` of functions like `on_load()`, `
 | [package:buildhash](#packagebuildhash)         | Get the build hash of the package                                            | >= 2.2.5           |
 | [package:group](#packagegroup)                 | Get the group name of the package                                            | >= 2.2.3           |
 | [package:patches](#packagepatches)             | Get all patches of the current version                                       | >= 2.2.5           |
+| [package:has_cfuncs](#packagehas_cfuncs)       | Wether the package has the given C functions                                 | >= 2.2.5           |
 
 #### package:name
 
@@ -491,4 +492,20 @@ local patches = package:patches()
 -- each element contains the keys "url" and "sha256"
 local url = patches[1]["url"]
 local sha256 = patches[1]["sha256"]
+```
+
+#### package:has_cfuncs
+
+- Wether the package has the given C functions
+
+This should be used inside `on_test` like so:
+```lua
+on_test(function (package)
+  assert(package:has_cfuncs("foo"))
+  -- you can also add configs
+  assert(package:has_cfuncs("bar", {includes = "foo_bar.h"}))
+  assert(package:has_cfuncs("blob", {includes = "blob.h", configs = {defines = "USE_BLOB"}}))
+  -- you can even set the language
+  assert(package:has_cfuncs("bla", {configs = {languages = "c99"}}))
+end)
 ```

--- a/manual/package_interface.md
+++ b/manual/package_interface.md
@@ -31,6 +31,7 @@ This page describes the interface for `package` of functions like `on_load()`, `
 | [package:is_toolchain](#packageis_toolchain)   | Wether the package is of kind toolchain                                      | >= 2.5.2           |
 | [package:is_library](#packageis_library)       | Wether the package is of kind library                                        | >= 2.5.2           |
 | [package:is_toplevel](#packageis_toplevel)     | Wether the package is directly required by the user                          | >= 2.5.2           |
+| [package:is_thirdparty](#packageis_thirdparty) | Wether the package is provided by a third party package manager              | >= 2.5.3           |
 
 #### package:name
 
@@ -296,3 +297,8 @@ package:sourcehash(package:url_alias(package:urls()[1]))
 #### package:is_toplevel
 
 - Wether the package is directly required by the user (e.g. xmake.lua)
+
+
+#### package:is_thirdparty
+
+- Wether the package is provided by a thirdparty package manager (e.g. brew, conan, vcpkg)

--- a/manual/package_interface.md
+++ b/manual/package_interface.md
@@ -54,6 +54,7 @@ This page describes the interface for `package` of functions like `on_load()`, `
 | [package:group](#packagegroup)                 | Get the group name of the package                                            | >= 2.2.3           |
 | [package:patches](#packagepatches)             | Get all patches of the current version                                       | >= 2.2.5           |
 | [package:has_cfuncs](#packagehas_cfuncs)       | Wether the package has the given C functions                                 | >= 2.2.5           |
+| [package:has_cxxfuncs](#packagehas_cxxfuncs)   | Wether the package has the given C++ functions                               | >= 2.2.5           |
 
 #### package:name
 
@@ -507,5 +508,21 @@ on_test(function (package)
   assert(package:has_cfuncs("blob", {includes = "blob.h", configs = {defines = "USE_BLOB"}}))
   -- you can even set the language
   assert(package:has_cfuncs("bla", {configs = {languages = "c99"}}))
+end)
+```
+
+#### package:has_cxxfuncs
+
+- Wether the package has the given C++ functions
+
+This should be used inside `on_test` like so:
+```lua
+on_test(function (package)
+  assert(package:has_cxxfuncs("foo"))
+  -- you can also add configs
+  assert(package:has_cxxfuncs("bar", {includes = "foo_bar.hpp"}))
+  assert(package:has_cxxfuncs("blob", {includes = "blob.hpp", configs = {defines = "USE_BLOB"}}))
+  -- you can even set the language
+  assert(package:has_cxxfuncs("bla", {configs = {languages = "cxx17"}}))
 end)
 ```

--- a/manual/package_interface.md
+++ b/manual/package_interface.md
@@ -1,63 +1,64 @@
 
 This page describes the interface for `package` of functions like `on_load()`, `on_install()` or `on_test()` of the [Package Dependencies](manual/package_dependencies.md)
 
-| Interface                                      | Description                                                                  | Supported Versions |
-| ---------------------------------------------- | ---------------------------------------------------------------------------- | ------------------ |
-| [package:name](#packagename)                   | Get the name of the package                                                  | >= 2.2.5           |
-| [package:get](#packageget)                     | Get the values of the package                                                | >= 2.1.6           |
-| [package:set](#packageset)                     | Set the values of the package                                                | >= 2.1.6           |
-| [package:add](#packageadd)                     | Add to the values of the package                                             | >= 2.2.5           |
-| [package:license](#packagelicense)             | Get the license of the package                                               | >= 2.3.9           |
-| [package:description](#packagedescription)     | Get the description of the package                                           | >= 2.2.3           |
-| [package:plat](#packageplat)                   | Get the platform of the package                                              | >= 2.2.2           |
-| [package:arch](#packagearch)                   | Get the architecture of the package                                          | >= 2.2.2           |
-| [package:targetos](#packagetargetos)           | Get the targeted OS of the package                                           | >= 2.5.2           |
-| [package:targetarch](#packagetargetarch)       | Get the targeted architecture of the package                                 | >= 2.5.2           |
-| [package:mode](#packagemode)                   | Get the build mode of the package                                            | >= 2.2.5           |
-| [package:is_plat](#packageis_plat)             | Wether the current platform is one of the given platforms                    | >= 2.2.6           |
-| [package:is_arch](#packageis_arch)             | Wether the current architecture is one of the given platforms                | >= 2.2.6           |
-| [package:is_targetos](#packageis_targetos)     | Wether the currently targeted OS is one of the given OS                      | >= 2.5.2           |
-| [package:is_targetarch](#packageis_targetarch) | Wether the currently targeted architecture is one of the given architectures | >= 2.5.2           |
-| [package:alias](#packagealias)                 | Get the alias of the package                                                 | >= 2.1.7           |
-| [package:urls](#packageurls)                   | Get the URLs of the package                                                  | >= 2.1.6           |
-| [package:urls_set](#packageurls_set)           | Set the URLs of the package                                                  | >= 2.1.6           |
-| [package:url_alias](#packageurl_alias)         | Get the alias of an URL                                                      | >= 2.1.6           |
-| [package:url_version](#packageurl_version)     | Get the version filter of an URL                                             | >= 2.1.6           |
-| [package:dep](#packagedep)                     | Get a dependency of the package                                              | >= 2.2.3           |
-| [package:deps](#packagedeps)                   | Get all dependencies of the package                                          | >= 2.1.7           |
-| [package:sourcehash](#packagesourcehash)       | Get the sha256 checksum of an URL alias                                      | >= 2.3.2           |
-| [package:kind](#packagekind)                   | Get the kind of the package                                                  | >= 2.1.7           |
-| [package:is_binary](#packageis_binary)         | Wether the package is of kind binary                                         | >= 2.5.2           |
-| [package:is_toolchain](#packageis_toolchain)   | Wether the package is of kind toolchain                                      | >= 2.5.2           |
-| [package:is_library](#packageis_library)       | Wether the package is of kind library                                        | >= 2.5.2           |
-| [package:is_toplevel](#packageis_toplevel)     | Wether the package is directly required by the user                          | >= 2.5.2           |
-| [package:is_thirdparty](#packageis_thirdparty) | Wether the package is provided by a third party package manager              | >= 2.5.3           |
-| [package:is_debug](#packageis_debug)           | Wether the the package gets built with debug mode                            | >= 2.5.3           |
-| [package:is_supported](#packageis_supported)   | Wether the package is supported by the current platform and architecture     | >= 2.5.3           |
-| [package:debug](#packagedebug)                 | Wether the the package gets built with debug mode (deprecated)               | >= 2.2.3           |
-| [package:is_cross](#packageis_cross)           | Wether the package is getting cross-compiled                                 | >= 2.5.3           |
-| [package:cachedir](#packagecachedir)           | Get the cache directory of the package                                       | >= 2.1.6           |
-| [package:installdir](#packageinstalldir)       | Get the installation directory of the package                                | >= 2.2.2           |
-| [package:scriptdir](#packagescriptdir)         | Get the directory where the xmake.lua of the package lies                    | >= 2.2.5           |
-| [package:envs](#packageenvs)                   | Get the exported environment variables of the package                        | >= 2.2.5           |
-| [package:getenv](#packagegetenv)               | Get the given environment variable                                           | >= 2.2.2           |
-| [package:setenv](#packagesetenv)               | Set the given environment variable                                           | >= 2.2.2           |
-| [package:addenv](#packageaddenv)               | Add the given values to the environment variable                             | >= 2.2.2           |
-| [package:versions](#packageversions)           | Get all version strings of the package                                       | >= 2.1.9           |
-| [package:version](#packageversion)             | Get the version of the package                                               | >= 2.1.6           |
-| [package:version_str](#packageversion_str)     | Get the version of the package as string                                     | >= 2.1.6           |
-| [package:version_set](#packageversion_set)     | Set the version of the package                                               | >= 2.1.6           |
-| [package:config](#packageconfig)               | Get the given configuration value of the package                             | >= 2.2.5           |
-| [package:config_set](#packageconfig_set)       | Set the given configuration value of the package                             | >= 2.5.1           |
-| [package:configs](#packageconfigs)             | Get all configurations of the package                                        | >= 2.2.2           |
-| [package:buildhash](#packagebuildhash)         | Get the build hash of the package                                            | >= 2.2.5           |
-| [package:group](#packagegroup)                 | Get the group name of the package                                            | >= 2.2.3           |
-| [package:patches](#packagepatches)             | Get all patches of the current version                                       | >= 2.2.5           |
-| [package:has_cfuncs](#packagehas_cfuncs)       | Wether the package has the given C functions                                 | >= 2.2.5           |
-| [package:has_cxxfuncs](#packagehas_cxxfuncs)   | Wether the package has the given C++ functions                               | >= 2.2.5           |
-| [package:has_ctypes](#packagehas_ctypes)       | Wether the package has the given C types                                     | >= 2.3.8           |
-| [package:has_cxxtypes](#packagehas_cxxtypes)   | Wether the package has the given C++ types                                   | >= 2.3.8           |
-| [package:has_cincludes](#packagehas_cincludes) | Wether the package has the given C header files                              | >= 2.3.8           |
+| Interface                                          | Description                                                                  | Supported Versions |
+| -------------------------------------------------- | ---------------------------------------------------------------------------- | ------------------ |
+| [package:name](#packagename)                       | Get the name of the package                                                  | >= 2.2.5           |
+| [package:get](#packageget)                         | Get the values of the package                                                | >= 2.1.6           |
+| [package:set](#packageset)                         | Set the values of the package                                                | >= 2.1.6           |
+| [package:add](#packageadd)                         | Add to the values of the package                                             | >= 2.2.5           |
+| [package:license](#packagelicense)                 | Get the license of the package                                               | >= 2.3.9           |
+| [package:description](#packagedescription)         | Get the description of the package                                           | >= 2.2.3           |
+| [package:plat](#packageplat)                       | Get the platform of the package                                              | >= 2.2.2           |
+| [package:arch](#packagearch)                       | Get the architecture of the package                                          | >= 2.2.2           |
+| [package:targetos](#packagetargetos)               | Get the targeted OS of the package                                           | >= 2.5.2           |
+| [package:targetarch](#packagetargetarch)           | Get the targeted architecture of the package                                 | >= 2.5.2           |
+| [package:mode](#packagemode)                       | Get the build mode of the package                                            | >= 2.2.5           |
+| [package:is_plat](#packageis_plat)                 | Wether the current platform is one of the given platforms                    | >= 2.2.6           |
+| [package:is_arch](#packageis_arch)                 | Wether the current architecture is one of the given platforms                | >= 2.2.6           |
+| [package:is_targetos](#packageis_targetos)         | Wether the currently targeted OS is one of the given OS                      | >= 2.5.2           |
+| [package:is_targetarch](#packageis_targetarch)     | Wether the currently targeted architecture is one of the given architectures | >= 2.5.2           |
+| [package:alias](#packagealias)                     | Get the alias of the package                                                 | >= 2.1.7           |
+| [package:urls](#packageurls)                       | Get the URLs of the package                                                  | >= 2.1.6           |
+| [package:urls_set](#packageurls_set)               | Set the URLs of the package                                                  | >= 2.1.6           |
+| [package:url_alias](#packageurl_alias)             | Get the alias of an URL                                                      | >= 2.1.6           |
+| [package:url_version](#packageurl_version)         | Get the version filter of an URL                                             | >= 2.1.6           |
+| [package:dep](#packagedep)                         | Get a dependency of the package                                              | >= 2.2.3           |
+| [package:deps](#packagedeps)                       | Get all dependencies of the package                                          | >= 2.1.7           |
+| [package:sourcehash](#packagesourcehash)           | Get the sha256 checksum of an URL alias                                      | >= 2.3.2           |
+| [package:kind](#packagekind)                       | Get the kind of the package                                                  | >= 2.1.7           |
+| [package:is_binary](#packageis_binary)             | Wether the package is of kind binary                                         | >= 2.5.2           |
+| [package:is_toolchain](#packageis_toolchain)       | Wether the package is of kind toolchain                                      | >= 2.5.2           |
+| [package:is_library](#packageis_library)           | Wether the package is of kind library                                        | >= 2.5.2           |
+| [package:is_toplevel](#packageis_toplevel)         | Wether the package is directly required by the user                          | >= 2.5.2           |
+| [package:is_thirdparty](#packageis_thirdparty)     | Wether the package is provided by a third party package manager              | >= 2.5.3           |
+| [package:is_debug](#packageis_debug)               | Wether the the package gets built with debug mode                            | >= 2.5.3           |
+| [package:is_supported](#packageis_supported)       | Wether the package is supported by the current platform and architecture     | >= 2.5.3           |
+| [package:debug](#packagedebug)                     | Wether the the package gets built with debug mode (deprecated)               | >= 2.2.3           |
+| [package:is_cross](#packageis_cross)               | Wether the package is getting cross-compiled                                 | >= 2.5.3           |
+| [package:cachedir](#packagecachedir)               | Get the cache directory of the package                                       | >= 2.1.6           |
+| [package:installdir](#packageinstalldir)           | Get the installation directory of the package                                | >= 2.2.2           |
+| [package:scriptdir](#packagescriptdir)             | Get the directory where the xmake.lua of the package lies                    | >= 2.2.5           |
+| [package:envs](#packageenvs)                       | Get the exported environment variables of the package                        | >= 2.2.5           |
+| [package:getenv](#packagegetenv)                   | Get the given environment variable                                           | >= 2.2.2           |
+| [package:setenv](#packagesetenv)                   | Set the given environment variable                                           | >= 2.2.2           |
+| [package:addenv](#packageaddenv)                   | Add the given values to the environment variable                             | >= 2.2.2           |
+| [package:versions](#packageversions)               | Get all version strings of the package                                       | >= 2.1.9           |
+| [package:version](#packageversion)                 | Get the version of the package                                               | >= 2.1.6           |
+| [package:version_str](#packageversion_str)         | Get the version of the package as string                                     | >= 2.1.6           |
+| [package:version_set](#packageversion_set)         | Set the version of the package                                               | >= 2.1.6           |
+| [package:config](#packageconfig)                   | Get the given configuration value of the package                             | >= 2.2.5           |
+| [package:config_set](#packageconfig_set)           | Set the given configuration value of the package                             | >= 2.5.1           |
+| [package:configs](#packageconfigs)                 | Get all configurations of the package                                        | >= 2.2.2           |
+| [package:buildhash](#packagebuildhash)             | Get the build hash of the package                                            | >= 2.2.5           |
+| [package:group](#packagegroup)                     | Get the group name of the package                                            | >= 2.2.3           |
+| [package:patches](#packagepatches)                 | Get all patches of the current version                                       | >= 2.2.5           |
+| [package:has_cfuncs](#packagehas_cfuncs)           | Wether the package has the given C functions                                 | >= 2.2.5           |
+| [package:has_cxxfuncs](#packagehas_cxxfuncs)       | Wether the package has the given C++ functions                               | >= 2.2.5           |
+| [package:has_ctypes](#packagehas_ctypes)           | Wether the package has the given C types                                     | >= 2.3.8           |
+| [package:has_cxxtypes](#packagehas_cxxtypes)       | Wether the package has the given C++ types                                   | >= 2.3.8           |
+| [package:has_cincludes](#packagehas_cincludes)     | Wether the package has the given C header files                              | >= 2.3.8           |
+| [package:has_cxxincludes](#packagehas_cxxincludes) | Wether the package has the given C++ header files                            | >= 2.3.8           |
 
 #### package:name
 
@@ -570,5 +571,16 @@ This should be used in `on_test` like so:
 ```lua
 on_test(function (package)
   assert(package:has_cincludes("foo.h"))
+end)
+```
+
+#### package:has_cxxincludes
+
+- Wether the package has the given C++ header files
+
+This should be used in `on_test` like so:
+```lua
+on_test(function (package)
+  assert(package:has_cincludes("foo.hpp"))
 end)
 ```

--- a/manual/package_interface.md
+++ b/manual/package_interface.md
@@ -50,6 +50,7 @@ This page describes the interface for `package` of functions like `on_load()`, `
 | [package:config](#packageconfig)               | Get the given configuration value of the package                             | >= 2.2.5           |
 | [package:config_set](#packageconfig_set)       | Set the given configuration value of the package                             | >= 2.5.1           |
 | [package:configs](#packageconfigs)             | Get all configurations of the package                                        | >= 2.2.2           |
+| [package:buildhash](#packagebuildhash)         | Get the build hash of the package                                            | >= 2.2.5           |
 
 #### package:name
 
@@ -467,3 +468,7 @@ local configs = package:configs()
 local enable_x = configs["enable_x"]
 local value_y = configs["value_y"]
 ```
+
+#### package:buildhash
+
+- Get the build hash of the package

--- a/manual/package_interface.md
+++ b/manual/package_interface.md
@@ -1,15 +1,16 @@
 
 This page describes the interface for `package` of functions like `on_load()`, `on_install()` or `on_test()` of the [Package Dependencies](manual/package_dependencies.md)
 
-| Interface                                  | Description                        | Supported Versions |
-| ------------------------------------------ | ---------------------------------- | ------------------ |
-| [package:name](#packagename)               | Get the name of the package        | >= 2.2.5           |
-| [package:get](#packageget)                 | Get the values of the package      | >= 2.1.6           |
-| [package:set](#packageset)                 | Set the values of the package      | >= 2.1.6           |
-| [package:add](#packageadd)                 | Add to the values of the package   | >= 2.2.5           |
-| [package:license](#packagelicense)         | Get the license of the package     | >= 2.3.9           |
-| [package:description](#packagedescription) | Get the description of the package | >= 2.2.3           |
-| [package:plat](#packageplat)               | Get the platform of the package    | >= 2.2.2           |
+| Interface                                  | Description                         | Supported Versions |
+| ------------------------------------------ | ----------------------------------- | ------------------ |
+| [package:name](#packagename)               | Get the name of the package         | >= 2.2.5           |
+| [package:get](#packageget)                 | Get the values of the package       | >= 2.1.6           |
+| [package:set](#packageset)                 | Set the values of the package       | >= 2.1.6           |
+| [package:add](#packageadd)                 | Add to the values of the package    | >= 2.2.5           |
+| [package:license](#packagelicense)         | Get the license of the package      | >= 2.3.9           |
+| [package:description](#packagedescription) | Get the description of the package  | >= 2.2.3           |
+| [package:plat](#packageplat)               | Get the platform of the package     | >= 2.2.2           |
+| [package:arch](#packagearch)               | Get the architecture of the package | >= 2.2.2           |
 
 #### package:name
 
@@ -76,3 +77,9 @@ package:add("defines", "SDL_MAIN_HANDLED")
   + bsd
 
 If the package is binary [`os.host`](manual/builtin_modules.md#oshost) is returned
+
+#### package:arch
+
+- Get the architecture of the package (e.g. x86, x64, x86_64)
+
+If the package is binary [`os.arch`](manual/builtin_modules.md#osarch) is returned

--- a/manual/package_interface.md
+++ b/manual/package_interface.md
@@ -38,6 +38,7 @@ This page describes the interface for `package` of functions like `on_load()`, `
 | [package:is_cross](#packageis_cross)           | Wether the package is getting cross-compiled                                 | >= 2.5.3           |
 | [package:cachedir](#packagecachedir)           | Get the cache directory of the package                                       | >= 2.1.6           |
 | [package:installdir](#packageinstalldir)       | Get the installation directory of the package                                | >= 2.2.2           |
+| [package:scriptdir](#packagescriptdir)         | Get the directory where the xmake.lua of the package lies                    | >= 2.2.5           |
 
 #### package:name
 
@@ -347,3 +348,7 @@ package:installdir("include")
 -- returns the subdirectory include/files
 package:installdir("include", "files")
 ```
+
+#### package:scriptdir
+
+- Get the directory where the xmake.lua of the package lies

--- a/manual/package_interface.md
+++ b/manual/package_interface.md
@@ -56,6 +56,7 @@ This page describes the interface for `package` of functions like `on_load()`, `
 | [package:has_cfuncs](#packagehas_cfuncs)       | Wether the package has the given C functions                                 | >= 2.2.5           |
 | [package:has_cxxfuncs](#packagehas_cxxfuncs)   | Wether the package has the given C++ functions                               | >= 2.2.5           |
 | [package:has_ctypes](#packagehas_ctypes)       | Wether the package has the given C types                                     | >= 2.3.8           |
+| [package:has_cxxtypes](#packagehas_cxxtypes)   | Wether the package has the given C++ types                                   | >= 2.3.8           |
 
 #### package:name
 
@@ -541,5 +542,21 @@ on_test(function (package)
   assert(package:has_ctypes("blob", {includes = "blob.h", configs = {defines = "USE_BLOB"}}))
   -- you can even set the language
   assert(package:has_ctypes("bla", {configs = {languages = "c99"}}))
+end)
+```
+
+#### package:has_cxxtypes
+
+- Wether the package has the given C++ types
+
+This should be used inside `on_test` like so:
+```lua
+on_test(function (package)
+  assert(package:has_cxxtypes("foo"))
+  -- you can also add configs
+  assert(package:has_cxxtypes("bar", {includes = "foo_bar.hpp"}))
+  assert(package:has_cxxtypes("blob", {includes = "blob.hpp", configs = {defines = "USE_BLOB"}}))
+  -- you can even set the language
+  assert(package:has_cxxtypes("bla", {configs = {languages = "cxx17"}}))
 end)
 ```

--- a/manual/package_interface.md
+++ b/manual/package_interface.md
@@ -35,6 +35,7 @@ This page describes the interface for `package` of functions like `on_load()`, `
 | [package:is_debug](#packageis_debug)           | Wether the the package gets built with debug mode                            | >= 2.5.3           |
 | [package:is_supported](#packageis_supported)   | Wether the package is supported by the current platform and architecture     | >= 2.5.3           |
 | [package:debug](#packagedebug)                 | Wether the the package gets built with debug mode (deprecated)               | >= 2.2.3           |
+| [package:is_cross](#packageis_cross)           | Wether the package is getting cross-compiled                                 | >= 2.5.3           |
 
 #### package:name
 
@@ -320,3 +321,8 @@ package:sourcehash(package:url_alias(package:urls()[1]))
 #### package:debug
 
 - Wether the the package gets built with debug mode (deprecated: use [`package:is_debug`](#packageis_debug) instead)
+
+
+#### package:is_cross
+
+- Wether the package is getting cross-compiled

--- a/manual/package_interface.md
+++ b/manual/package_interface.md
@@ -24,6 +24,7 @@ This page describes the interface for `package` of functions like `on_load()`, `
 | [package:url_alias](#packageurl_alias)         | Get the alias of an URL                                                      | >= 2.1.6           |
 | [package:url_version](#packageurl_version)     | Get the version filter of an URL                                             | >= 2.1.6           |
 | [package:dep](#packagedep)                     | Get a dependency of the package                                              | >= 2.2.3           |
+| [package:deps](#packagedeps)                   | Get all dependencies of the package                                          | >= 2.1.7           |
 
 #### package:name
 
@@ -234,4 +235,15 @@ version_func()
 local python = package:dep("python")
 -- returns "python"
 python:name()
+```
+
+#### package:deps
+
+- Get all dependencies of the package
+
+```lua
+-- prints the names of all dependencies
+for _,dep in pairs(package:deps()) do
+    print(dep:name())
+end
 ```

--- a/manual/package_interface.md
+++ b/manual/package_interface.md
@@ -30,6 +30,7 @@ This page describes the interface for `package` of functions like `on_load()`, `
 | [package:is_binary](#packageis_binary)         | Wether the package is of kind binary                                         | >= 2.5.2           |
 | [package:is_toolchain](#packageis_toolchain)   | Wether the package is of kind toolchain                                      | >= 2.5.2           |
 | [package:is_library](#packageis_library)       | Wether the package is of kind library                                        | >= 2.5.2           |
+| [package:is_toplevel](#packageis_toplevel)     | Wether the package is directly required by the user                          | >= 2.5.2           |
 
 #### package:name
 
@@ -291,3 +292,7 @@ package:sourcehash(package:url_alias(package:urls()[1]))
 #### package:is_library
 
 - Wether the package is of kind library
+
+#### package:is_toplevel
+
+- Wether the package is directly required by the user (e.g. xmake.lua)

--- a/manual/package_interface.md
+++ b/manual/package_interface.md
@@ -46,6 +46,7 @@ This page describes the interface for `package` of functions like `on_load()`, `
 | [package:versions](#packageversions)           | Get all version strings of the package                                       | >= 2.1.9           |
 | [package:version](#packageversion)             | Get the version of the package                                               | >= 2.1.6           |
 | [package:version_str](#packageversion_str)     | Get the version of the package as string                                     | >= 2.1.6           |
+| [package:version_set](#packageversion_set)     | Set the version of the package                                               | >= 2.1.6           |
 
 #### package:name
 
@@ -415,3 +416,17 @@ version:patch()
 #### package:version_str
 
 - Get the version of the package as string
+
+
+#### package:version_set
+
+- Set the version of the package
+
+```lua
+-- normal semantic version
+package:version_set("2.4.1", "versions")
+-- branch for git repo
+package:version_set("dev", "branches")
+-- tag of git repo
+package:version_set("v2.4.1", "tags")
+```

--- a/manual/package_interface.md
+++ b/manual/package_interface.md
@@ -25,6 +25,7 @@ This page describes the interface for `package` of functions like `on_load()`, `
 | [package:url_version](#packageurl_version)     | Get the version filter of an URL                                             | >= 2.1.6           |
 | [package:dep](#packagedep)                     | Get a dependency of the package                                              | >= 2.2.3           |
 | [package:deps](#packagedeps)                   | Get all dependencies of the package                                          | >= 2.1.7           |
+| [package:sourcehash](#packagesourcehash)       | Get the sha256 checksum of an URL alias                                      | >= 2.3.2           |
 
 #### package:name
 
@@ -246,4 +247,21 @@ python:name()
 for _,dep in pairs(package:deps()) do
     print(dep:name())
 end
+```
+
+#### package:sourcehash
+
+- Get the sha256 checksum of an URL alias
+
+If the checksum is provided like so:
+```lua
+add_urls("https://example.com/library-$(version).zip", {alias = "example"})
+add_versions("example:2.4.1", "29f9983cc7196e882c4bc3d23d7492f9c47574c7cf658afafe7d00c185429941")
+```
+You can retrieve the checksum like so:
+```lua
+-- returns "29f9983cc7196e882c4bc3d23d7492f9c47574c7cf658afafe7d00c185429941"
+package:sourcehash("example")
+-- or so
+package:sourcehash(package:url_alias(package:urls()[1]))
 ```

--- a/manual/package_interface.md
+++ b/manual/package_interface.md
@@ -23,6 +23,7 @@ This page describes the interface for `package` of functions like `on_load()`, `
 | [package:urls_set](#packageurls_set)           | Set the URLs of the package                                                  | >= 2.1.6           |
 | [package:url_alias](#packageurl_alias)         | Get the alias of an URL                                                      | >= 2.1.6           |
 | [package:url_version](#packageurl_version)     | Get the version filter of an URL                                             | >= 2.1.6           |
+| [package:dep](#packagedep)                     | Get a dependency of the package                                              | >= 2.2.3           |
 
 #### package:name
 
@@ -223,4 +224,14 @@ It can be used like so:
 local version_func = package:url_version(package:urls()[1])
 -- returns "example_version"
 version_func()
+```
+
+#### package:dep
+
+- Get a dependency of the package by name. The name needs to be a dependency of the package.
+
+```lua
+local python = package:dep("python")
+-- returns "python"
+python:name()
 ```

--- a/manual/package_interface.md
+++ b/manual/package_interface.md
@@ -43,6 +43,7 @@ This page describes the interface for `package` of functions like `on_load()`, `
 | [package:getenv](#packagegetenv)               | Get the given environment variable                                           | >= 2.2.2           |
 | [package:setenv](#packagesetenv)               | Set the given environment variable                                           | >= 2.2.2           |
 | [package:addenv](#packageaddenv)               | Add the given values to the environment variable                             | >= 2.2.2           |
+| [package:versions](#packageversions)           | Get all version strings of the package                                       | >= 2.1.9           |
 
 #### package:name
 
@@ -389,3 +390,7 @@ package:setenv("PATH", "bin", "lib")
 -- adds "bin" and "lib" to PATH
 package:addenv("PATH", "bin", "lib")
 ```
+
+#### package:versions
+
+- Get all version strings of the package. Returns a table containing all versions as strings

--- a/manual/package_interface.md
+++ b/manual/package_interface.md
@@ -1,10 +1,24 @@
 
 This page describes the interface for `package` of functions like `on_load()`, `on_install()` or `on_test()` of the [Package Dependencies](manual/package_dependencies.md)
 
-| Interface                    | Description                 | Supported Versions |
-| ---------------------------- | --------------------------- | ------------------ |
-| [package:name](#packagename) | Get the name of the package | >= 2.2.5           |
+| Interface                    | Description                   | Supported Versions |
+| ---------------------------- | ----------------------------- | ------------------ |
+| [package:name](#packagename) | Get the name of the package   | >= 2.2.5           |
+| [package:get](#packageget)   | Get the values of the package | >= 2.1.6           |
 
 #### package:name
 
 - Get the name of the package
+
+#### package:get
+
+- Get the values of the package by name
+
+```lua
+-- get the dependencies
+package:get("deps")
+-- get the links
+package:get("links")
+-- get the defined macros
+package:get("defines")
+```

--- a/manual/package_interface.md
+++ b/manual/package_interface.md
@@ -16,6 +16,7 @@ This page describes the interface for `package` of functions like `on_load()`, `
 | [package:mode](#packagemode)               | Get the build mode of the package                             | >= 2.2.5           |
 | [package:is_plat](#packageis_plat)         | Wether the current platform is one of the given platforms     | >= 2.2.6           |
 | [package:is_arch](#packageis_arch)         | Wether the current architecture is one of the given platforms | >= 2.2.6           |
+| [package:is_targetos](#packageis_targetos) | Wether the currently targeted OS is one of the given OS       | >= 2.5.2           |
 
 #### package:name
 
@@ -123,4 +124,15 @@ package:is_plat("windows", "linux", "macosx")
 package:is_arch("x86")
 -- Is the current architecture x64 or x86_64
 package:is_arch("x64", "x86_64")
+```
+
+#### package:is_targetos
+
+- Wether the currently targeted OS is one of the given OS
+
+```lua
+-- Is the currently targeted OS windows?
+package:is_targetos("windows")
+-- Is the currently targeted OS android or iphoneos?
+package:is_targetos("android", "iphoneos")
 ```

--- a/manual/package_interface.md
+++ b/manual/package_interface.md
@@ -48,6 +48,7 @@ This page describes the interface for `package` of functions like `on_load()`, `
 | [package:version_str](#packageversion_str)     | Get the version of the package as string                                     | >= 2.1.6           |
 | [package:version_set](#packageversion_set)     | Set the version of the package                                               | >= 2.1.6           |
 | [package:config](#packageconfig)               | Get the given configuration value of the package                             | >= 2.2.5           |
+| [package:config_set](#packageconfig_set)       | Set the given configuration value of the package                             | >= 2.5.1           |
 
 #### package:name
 
@@ -444,4 +445,13 @@ add_require("example", {config = {enable_x = true, value_y = 6}})
 package:config("enable_x")
 -- returns 6
 package:config("value_y")
+```
+
+#### package:config_set
+
+- Set the given configuration value of the package
+
+```lua
+package:config_set("enable_x", true)
+package:config_set("value_y", 6)
 ```

--- a/manual/package_interface.md
+++ b/manual/package_interface.md
@@ -59,6 +59,7 @@ This page describes the interface for `package` of functions like `on_load()`, `
 | [package:has_cxxtypes](#packagehas_cxxtypes)       | Wether the package has the given C++ types                                   | >= 2.3.8           |
 | [package:has_cincludes](#packagehas_cincludes)     | Wether the package has the given C header files                              | >= 2.3.8           |
 | [package:has_cxxincludes](#packagehas_cxxincludes) | Wether the package has the given C++ header files                            | >= 2.3.8           |
+| [package:check_csnippets](#packagecheck_csnippets) | Wether the given C snippet can be compiled and linked                        | >= 2.2.6           |
 
 #### package:name
 
@@ -582,5 +583,23 @@ This should be used in `on_test` like so:
 ```lua
 on_test(function (package)
   assert(package:has_cincludes("foo.hpp"))
+end)
+```
+
+#### package:check_csnippets
+
+- Wether the given C snippet can be compiled and linked
+
+This should be used in `on_test` like so:
+```lua
+on_test(function (package)
+  assert(package:check_csnippets({test = [[
+    #define USE_BLOB
+    #include <blob.h>
+    void test(int argc, char** argv) {
+      foo bar;
+      printf("%s", bar.blob);
+    }
+  ]]}, {configs = {languages = "c99"}, includes = "foo.h"}))
 end)
 ```

--- a/manual/package_interface.md
+++ b/manual/package_interface.md
@@ -1,12 +1,14 @@
 
 This page describes the interface for `package` of functions like `on_load()`, `on_install()` or `on_test()` of the [Package Dependencies](manual/package_dependencies.md)
 
-| Interface                    | Description                      | Supported Versions |
-| ---------------------------- | -------------------------------- | ------------------ |
-| [package:name](#packagename) | Get the name of the package      | >= 2.2.5           |
-| [package:get](#packageget)   | Get the values of the package    | >= 2.1.6           |
-| [package:set](#packageset)   | Set the values of the package    | >= 2.1.6           |
-| [package:add](#packageadd)   | Add to the values of the package | >= 2.2.5           |
+| Interface                                  | Description                        | Supported Versions |
+| ------------------------------------------ | ---------------------------------- | ------------------ |
+| [package:name](#packagename)               | Get the name of the package        | >= 2.2.5           |
+| [package:get](#packageget)                 | Get the values of the package      | >= 2.1.6           |
+| [package:set](#packageset)                 | Set the values of the package      | >= 2.1.6           |
+| [package:add](#packageadd)                 | Add to the values of the package   | >= 2.2.5           |
+| [package:license](#packagelicense)         | Get the license of the package     | >= 2.3.9           |
+| [package:description](#packagedescription) | Get the description of the package | >= 2.2.3           |
 
 #### package:name
 
@@ -50,3 +52,11 @@ package:add("links", "sdl2")
 -- add defined macros
 package:add("defines", "SDL_MAIN_HANDLED")
 ```
+
+#### package:license
+
+- Get the license of the package (Same as `package:get("license")`)
+
+#### package:description
+
+- Get the description of the package (Same as `package:get("description")`)

--- a/manual/package_interface.md
+++ b/manual/package_interface.md
@@ -9,6 +9,7 @@ This page describes the interface for `package` of functions like `on_load()`, `
 | [package:add](#packageadd)                 | Add to the values of the package   | >= 2.2.5           |
 | [package:license](#packagelicense)         | Get the license of the package     | >= 2.3.9           |
 | [package:description](#packagedescription) | Get the description of the package | >= 2.2.3           |
+| [package:plat](#packageplat)               | Get the platform of the package    | >= 2.2.2           |
 
 #### package:name
 
@@ -60,3 +61,18 @@ package:add("defines", "SDL_MAIN_HANDLED")
 #### package:description
 
 - Get the description of the package (Same as `package:get("description")`)
+
+#### package:plat
+
+- Get the platform of the package. Can be any of:
+  + windows
+  + linux
+  + macosx
+  + android
+  + iphoneos
+  + watchos
+  + mingw
+  + cygwin
+  + bsd
+
+If the package is binary [`os.host`](manual/builtin_modules.md#oshost) is returned

--- a/manual/package_interface.md
+++ b/manual/package_interface.md
@@ -1,1 +1,10 @@
-# Package Interface
+
+This page describes the interface for `package` of functions like `on_load()`, `on_install()` or `on_test()` of the [Package Dependencies](manual/package_dependencies.md)
+
+| Interface                    | Description                 | Supported Versions |
+| ---------------------------- | --------------------------- | ------------------ |
+| [package:name](#packagename) | Get the name of the package | >= 2.2.5           |
+
+#### package:name
+
+- Get the name of the package

--- a/manual/package_interface.md
+++ b/manual/package_interface.md
@@ -19,6 +19,7 @@ This page describes the interface for `package` of functions like `on_load()`, `
 | [package:is_targetos](#packageis_targetos)     | Wether the currently targeted OS is one of the given OS                      | >= 2.5.2           |
 | [package:is_targetarch](#packageis_targetarch) | Wether the currently targeted architecture is one of the given architectures | >= 2.5.2           |
 | [package:alias](#packagealias)                 | Get the alias of the package                                                 | >= 2.1.7           |
+| [package:urls](#packageurls)                   | Get the URLs of the package                                                  | >= 2.1.6           |
 
 #### package:name
 
@@ -162,4 +163,20 @@ This alias can be retrieved by
 ```lua
 -- returns "sdl"
 package:alias()
+```
+
+#### package:urls
+
+- Get the URLs of the package
+
+Retrieve the URLs set by:
+```lua
+add_urls("https://example.com/library-$(version).zip")
+-- or so
+set_urls("https://example.com/library-$(version).zip")
+```
+Then write this:
+```lua
+-- returns the table {"https://example.com/library-$(version).zip"}
+package:urls()
 ```

--- a/package/remote_package.md
+++ b/package/remote_package.md
@@ -912,7 +912,7 @@ on_load(function (package)
 end)
 ```
 
-The pcre package needs to do some judgment on the bitwidth to determine the name of the link library for external output. It also needs to add some defines to the dynamic library. This time, it is more flexible when set in on_load.
+The pcre package needs to do some judgment on the bitwidth to determine the name of the link library for external output. It also needs to add some defines to the dynamic library. This time, it is more flexible when set in on_load. To find out what methods are available to `package` look [here](manual/package_interface.md).
 
 #### on_fetch
 
@@ -922,7 +922,7 @@ However, if some packages are installed in the system, the location is more comp
 
 Let's take libusb as an example. Instead of `add_extsources`, we can use the following method to achieve the same effect. Of course, we can do more things in it.
 
-```
+```lua
 package("libusb")
      on_fetch("linux", function(package, opt)
          if opt.system then
@@ -930,6 +930,8 @@ package("libusb")
          end
      end)
 ```
+
+To find out what methods are available to `package` look [here](manual/package_interface.md).
 
 #### on_install
 


### PR DESCRIPTION
This adds API documentation of the package interface which is used in `on_load`, `on_install`, `on_test` and such functions.