### PR TITLE
Fix typo: share library -> shared library

### DIFF
--- a/about/awesome.md
+++ b/about/awesome.md
@@ -37,7 +37,7 @@
 
 * [Executable Program](https://xmake.io/#/home?id=executable-program)
 * [Static Library Program](https://xmake.io/#/home?id=static-library-program)
-* [Dynamic Library Program](https://xmake.io/#/home?id=share-library-program)
+* [Dynamic Library Program](https://xmake.io/#/home?id=shared-library-program)
 * [Qt Program](https://xmake.io/#/home?id=qt-program)
 * [Cuda Program](https://xmake.io/#/home?id=cuda-program)
 * [WDK Driver Program](https://xmake.io/#/home?id=wdk-driver-program)

--- a/about/awesome.md
+++ b/about/awesome.md
@@ -35,13 +35,13 @@
 
 ## Examples
 
-* [Executable Program](https://xmake.io/#/home?id=executable-program)
-* [Static Library Program](https://xmake.io/#/home?id=static-library-program)
-* [Dynamic Library Program](https://xmake.io/#/home?id=shared-library-program)
-* [Qt Program](https://xmake.io/#/home?id=qt-program)
-* [Cuda Program](https://xmake.io/#/home?id=cuda-program)
-* [WDK Driver Program](https://xmake.io/#/home?id=wdk-driver-program)
-* [WinSDK Application Program](https://xmake.io/#/home?id=winsdk-application-program)
+* [Executable Program](https://xmake.io/#/guide/project_examples?id=executable-program)
+* [Static Library Program](https://xmake.io/#/guide/project_examples?id=static-library-program)
+* [Dynamic Library Program](https://xmake.io/#/guide/project_examples?id=share-library-program)
+* [Qt Program](https://xmake.io/#/guide/project_examples?id=qt-program)
+* [Cuda Program](https://xmake.io/#/guide/project_examples?id=cuda-program)
+* [WDK Driver Program](https://xmake.io/#/guide/project_examples?id=wdk-driver-program)
+* [WinSDK Application Program](https://xmake.io/#/guide/project_examples?id=winsdk-application-program)
 
 ## Repositories
 

--- a/guide/project_examples.md
+++ b/guide/project_examples.md
@@ -43,7 +43,7 @@ For a complete example, execute the following command to create:
 xmake create -l c -t static test
 ```
 
-## Share Library Program
+## Shared Library Program
 
 ```lua
 target("library")
@@ -56,7 +56,7 @@ target("test")
     add_deps("library")
 ```
 
-We use `add_deps` to link a share library to test target.
+We use `add_deps` to link a shared library to test target.
 
 For a complete example, execute the following command to create:
 

--- a/zh-cn/about/awesome.md
+++ b/zh-cn/about/awesome.md
@@ -34,13 +34,13 @@
 
 ## 示例
 
-* [Executable Program](https://xmake.io/#/home?id=executable-program)
-* [Static Library Program](https://xmake.io/#/home?id=static-library-program)
-* [Dynamic Library Program](https://xmake.io/#/home?id=shared-library-program)
-* [Qt Program](https://xmake.io/#/home?id=qt-program)
-* [Cuda Program](https://xmake.io/#/home?id=cuda-program)
-* [WDK Driver Program](https://xmake.io/#/home?id=wdk-driver-program)
-* [WinSDK Application Program](https://xmake.io/#/home?id=winsdk-application-program)
+* [Executable Program](https://xmake.io/#/guide/project_examples?id=executable-program)
+* [Static Library Program](https://xmake.io/#/guide/project_examples?id=static-library-program)
+* [Dynamic Library Program](https://xmake.io/#/guide/project_examples?id=share-library-program)
+* [Qt Program](https://xmake.io/#/guide/project_examples?id=qt-program)
+* [Cuda Program](https://xmake.io/#/guide/project_examples?id=cuda-program)
+* [WDK Driver Program](https://xmake.io/#/guide/project_examples?id=wdk-driver-program)
+* [WinSDK Application Program](https://xmake.io/#/guide/project_examples?id=winsdk-application-program)
 
 ## 包仓库
 

--- a/zh-cn/about/awesome.md
+++ b/zh-cn/about/awesome.md
@@ -36,7 +36,7 @@
 
 * [Executable Program](https://xmake.io/#/home?id=executable-program)
 * [Static Library Program](https://xmake.io/#/home?id=static-library-program)
-* [Dynamic Library Program](https://xmake.io/#/home?id=share-library-program)
+* [Dynamic Library Program](https://xmake.io/#/home?id=shared-library-program)
 * [Qt Program](https://xmake.io/#/home?id=qt-program)
 * [Cuda Program](https://xmake.io/#/home?id=cuda-program)
 * [WDK Driver Program](https://xmake.io/#/home?id=wdk-driver-program)


### PR DESCRIPTION
It should always be _shared library_.

I left the typo in the changelog. Not sure if it makes sense to remove it from there too.