### PR TITLE
Fix typo in extension_modules.md

### DIFF
--- a/manual/extension_modules.md
+++ b/manual/extension_modules.md
@@ -561,7 +561,7 @@ end
 
 - Get compiled command line list
 
-A little different from [compiler.compargv](#compilercompargv) is that this interface returns a list of parameters, table representation, more convenient to operate:
+A little different from [compiler.compcmd](#compilercompcmd) is that this interface returns a list of parameters, table representation, more convenient to operate:
 
 ```lua
 local program, argv = compiler.compargv("xxx.c", "xxx.o")

--- a/zh-cn/manual/extension_modules.md
+++ b/zh-cn/manual/extension_modules.md
@@ -359,7 +359,7 @@ end
 
 - 获取编译命令行列表
 
-跟[compiler.compargv](#compilercompargv)稍微有点区别的是，此接口返回的是参数列表，table表示，更加方便操作：
+跟[compiler.compcmd](#compilercompcmd)稍微有点区别的是，此接口返回的是参数列表，table表示，更加方便操作：
 
 ```lua
 local program, argv = compiler.compargv("xxx.c", "xxx.o")


### PR DESCRIPTION
Hello, here compiler.compargv should be compiler.compcmd