### PR TITLE
Fix typo in builtin_plugins.md

### DIFF
--- a/plugin/builtin_plugins.md
+++ b/plugin/builtin_plugins.md
@@ -22,13 +22,13 @@ $ xmake project -k cmakelists
 $ xmake project -k ninja
 ```
 
-### Generate compiler_flags
+### Generate compile_flags
 
 ```console
-$ xmake project -k compiler_flags
+$ xmake project -k compile_flags
 ```
 
-### Generate compiler_commands
+### Generate compile_commands
 
 We can export the compilation commands info of all source files and it is JSON compilation database format.
 


### PR DESCRIPTION
`compiler_*` -> `compile_*`

was even correct in the command for `compile_commands`

made me think I've finally gone mad for a second