### PR TITLE
Fix capitalization in code example

### DIFF
--- a/guide/syntax_description.md
+++ b/guide/syntax_description.md
@@ -98,10 +98,10 @@ target("test")
         end
     end)
     after_build(function (target)
-        Import("core.project.config")
-        Local targetfile = target:targetfile()
-        Os.cp(targetfile, path.join(config.buildir(), path.filename(targetfile)))
-        Print("build %s", targetfile)
+        import("core.project.config")
+        local targetfile = target:targetfile()
+        os.cp(targetfile, path.join(config.buildir(), path.filename(targetfile)))
+        print("build %s", targetfile)
     end)
 ```
 


### PR DESCRIPTION
The script code example contains typos: the start letter is capitalized. I have updated the example to be lowercase


