### PR TITLE
fix: correct Vcpkg syntax in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ Xmake can automatically fetch and install dependencies!
 * [User-built repositories](https://xmake.io/#/package/remote_package?id=using-self-built-private-package-repository)
 * Conan (conan::openssl/1.1.1g)
 * Conda (conda::libpng 1.3.67)
-* Vcpkg (vcpkg:ffmpeg)
+* Vcpkg (vcpkg::ffmpeg)
 * Homebrew/Linuxbrew (brew::pcre2/libpcre2-8)
 * Pacman on archlinux/msys2 (pacman::libcurl)
 * Apt on ubuntu/debian (apt::zlib1g-dev)

--- a/getting_started.md
+++ b/getting_started.md
@@ -132,7 +132,7 @@ The test project: [xmake-core](https://github.com/xmake-io/xmake/tree/master/cor
 * [User-built repositories](https://xmake.io/#/package/remote_package?id=using-self-built-private-package-repository)
 * Conan (conan::openssl/1.1.1g)
 * Conda (conda::libpng 1.3.67)
-* Vcpkg (vcpkg:ffmpeg)
+* Vcpkg (vcpkg::ffmpeg)
 * Homebrew/Linuxbrew (brew::pcre2/libpcre2-8)
 * Pacman on archlinux/msys2 (pacman::libcurl)
 * Apt on ubuntu/debian (apt::zlib1g-dev)

--- a/manual/global_interfaces.md
+++ b/manual/global_interfaces.md
@@ -367,7 +367,7 @@ Currently, the following packages in the third-party package manager are support
 
 * Conan (conan::openssl/1.1.1g)
 * Conda (conda::libpng 1.3.67)
-* Vcpkg (vcpkg:ffmpeg)
+* Vcpkg (vcpkg::ffmpeg)
 * Homebrew/Linuxbrew (brew::pcre2/libpcre2-8)
 * Pacman on archlinux/msys2 (pacman::libcurl)
 * Apt on ubuntu/debian (apt::zlib1g-dev)

--- a/zh-cn/README.md
+++ b/zh-cn/README.md
@@ -151,7 +151,7 @@ $ xmake f --menu
 * [用户自建仓库](https://xmake.io/#/zh-cn/package/remote_package?id=%e4%bd%bf%e7%94%a8%e8%87%aa%e5%bb%ba%e7%a7%81%e6%9c%89%e5%8c%85%e4%bb%93%e5%ba%93)
 * Conan (conan::openssl/1.1.1g)
 * Conda (conda::libpng 1.3.67)
-* Vcpkg (vcpkg:ffmpeg)
+* Vcpkg (vcpkg::ffmpeg)
 * Homebrew/Linuxbrew (brew::pcre2/libpcre2-8)
 * Pacman on archlinux/msys2 (pacman::libcurl)
 * Apt on ubuntu/debian (apt::zlib1g-dev)

--- a/zh-cn/manual/global_interfaces.md
+++ b/zh-cn/manual/global_interfaces.md
@@ -368,7 +368,7 @@ add_requires("boost", {configs = {context = true, coroutine = true}})
 
 * Conan (conan::openssl/1.1.1g)
 * Conda (conda::libpng 1.3.67)
-* Vcpkg (vcpkg:ffmpeg)
+* Vcpkg (vcpkg::ffmpeg)
 * Homebrew/Linuxbrew (brew::pcre2/libpcre2-8)
 * Pacman on archlinux/msys2 (pacman::libcurl)
 * Apt on ubuntu/debian (apt::zlib1g-dev)


### PR DESCRIPTION
Small typo for vcpkg `add_requires` syntax. It was missing a semi-colon.
