### PR TITLE
Fix project target language typo

### DIFF
--- a/manual/project_target.md
+++ b/manual/project_target.md
@@ -530,8 +530,8 @@ The supported language standards currently have the following main ones:
 |`gnuxx20`    |`gnu++20`             |
 |`cxx2a`      |`c++2a`               |
 |`gnuxx2a`    |`gnu++2a`             |
-|`cxx20`      |`c++23`               |
-|`gnuxx20`    |`gnu++23`             |
+|`cxx23`      |`c++23`               |
+|`gnuxx23`    |`gnu++23`             |
 |`cxx2b`      |`c++2b`               |
 |`gnuxx2b`    |`gnu++2b`             |
 |`cxxlatest`  |`c++latest`           |


### PR DESCRIPTION
The value for supported language (c++23) for target mismatch the c++ language standard