### PR TITLE
Add cpp2 to the list of supported languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ $ xmake f --menu
 
 ## Supported languages
 
-* C and C++
+* C, C++ (including cpp2)
 * Objective-C and Objective-C++
 * Swift
 * Assembly


### PR DESCRIPTION
Add cpp2 to the website as supported 

Already supported since August 2023
https://github.com/xmake-io/xmake/pull/4140/files
