### PR TITLE
Minor update to getting_started.md

### DIFF
--- a/getting_started.md
+++ b/getting_started.md
@@ -170,7 +170,7 @@ The test project: [xmake-core](https://github.com/xmake-io/xmake/tree/master/cor
 
 ## Supported toolchains
 
-```bash
+```text
 $ xmake show -l toolchains
 xcode         Xcode IDE
 vs            VisualStudio IDE


### PR DESCRIPTION
This is a very minor update to getting_started.md, just to remove the syntax highlighting in the Supported Toolchains list so the `for`s don't get unnecessarily highlighted among all the other text.