### PR TITLE
switch to history router

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,6 +40,7 @@
       executeScript: true,
       loadSidebar: true,
       loadNavbar: true,
+      routerMode: 'history',
       mergeNavbar: true,
       mergeNavbar: true,
       notFoundPage: true,


### PR DESCRIPTION
xmake本身变动比较多，ai经常写出错误的用法。
cursor支持导入文档，但是由于现在xmake的文档用的docsify，索引这种文档有问题，改成history的应该能解决问题
![image](https://github.com/user-attachments/assets/9e6ff14c-ff28-472d-b48b-3ec2117c6b8c)
