### PR TITLE
feat(test): Document should_fail support for expected-failure tests

### DIFF
--- a/docs/api/description/project-target.md
+++ b/docs/api/description/project-target.md
@@ -3697,6 +3697,60 @@ running tests...
 100% tests passed, 0 tests failed out of 1, spent 0.006s
 ```
 
+#### Marking tests as expected to fail
+
+You can mark a test as *expected to fail* using the `should_fail` option. This is useful when validating:
+
+- crash handling
+- assertion or contract violations
+- features under development or known to be broken
+
+If a test marked with `should_fail = true` fails during execution, it is treated as a **success**. If it unexpectedly passes, the result will be highlighted in the test report as an **unexpected pass**, and the test will be marked as failed.
+
+The test summary will also group expected failures and unexpected passes accordingly.
+
+```lua
+target("test")
+    set_kind("binary")
+    add_files("tests/test_foo.cpp")
+
+    add_tests("crash_div_by_zero", {
+        runargs = { "--div-zero" },
+        should_fail = true
+    })
+
+    add_tests("crash_div_by_zero_fails", {
+        runargs = { "--div-zero" }
+    })
+
+    add_tests("normal_behavior", {
+        runargs = { "--safe" }
+    })
+
+    add_tests("normal_behavior_unexpected_pass", {
+        runargs = { "--safe" },
+        should_fail = true
+    })
+```
+Example output:
+```
+...
+report of tests:
+[ 25%]: test/crash_div_by_zero ............. expected failure 0.004s
+[ 50%]: test/crash_div_by_zero_fails........ failed 0.004s
+[ 75%]: test/normal_behavior ............... passed 0.015s
+[100%]: test/normal_behavior_unexpected_pass unexpected pass 0.015s
+
+50% tests passed, 1 test(s) failed, 1 unexpected pass(es), 1 expected failure(s) out of 4, spent 0.038s
+Detailed summary:
+Failed tests:
+ - test/crash_div_by_zero_fails
+Unexpected passes:
+ - test/normal_behavior_unexpected_pass
+Expected failures:
+ - test/crash_div_by_zero
+```
+
 #### Terminate if the first test fails
 
 By default, `xmake test` will wait until all tests have been run, no matter how many of them failed.

--- a/docs/zh/api/description/project-target.md
+++ b/docs/zh/api/description/project-target.md
@@ -3692,6 +3692,59 @@ running tests ...
 100% tests passed, 0 tests failed out of 1, spent 0.006s
 ```
 
+#### 标记测试为预期失败
+你可以使用 `should_fail` 选项将测试标记为预期失败。这在验证以下情况时非常有用：
+
+- 崩溃处理
+- 断言或契约违规
+- 正在开发或已知存在问题的功能
+
+如果一个设置了 `should_fail = true` 的测试在执行时失败了，它将被视为成功。但如果它意外通过，则会在测试报告中高亮显示为 **unexpected pass**，并将该测试标记为失败。
+
+测试摘要也会将预期失败和意外通过的测试进行分组展示。
+
+```lua
+target("test")
+    set_kind("binary")
+    add_files("tests/test_foo.cpp")
+
+    add_tests("crash_div_by_zero", {
+        runargs = { "--div-zero" },
+        should_fail = true
+    })
+
+    add_tests("crash_div_by_zero_fails", {
+        runargs = { "--div-zero" }
+    })
+
+    add_tests("normal_behavior", {
+        runargs = { "--safe" }
+    })
+
+    add_tests("normal_behavior_unexpected_pass", {
+        runargs = { "--safe" },
+        should_fail = true
+    })
+```
+示例输出：
+```
+...
+report of tests:
+[ 25%]: test/crash_div_by_zero ............. expected failure 0.004s
+[ 50%]: test/crash_div_by_zero_fails........ failed 0.004s
+[ 75%]: test/normal_behavior ............... passed 0.015s
+[100%]: test/normal_behavior_unexpected_pass unexpected pass 0.015s
+
+50% tests passed, 1 test(s) failed, 1 unexpected pass(es), 1 expected failure(s) out of 4, spent 0.038s
+Detailed summary:
+Failed tests:
+ - test/crash_div_by_zero_fails
+Unexpected passes:
+ - test/normal_behavior_unexpected_pass
+Expected failures:
+ - test/crash_div_by_zero
+```
+
 #### 首次测试失败就终止
 
 默认情况下，`xmake test` 会等到所有测试都运行完，不管里面有多少是没通过的。


### PR DESCRIPTION
Adds documentation for the should_fail option in test configurations, including behavior and example output.

Implementation PR: https://github.com/xmake-io/xmake/pull/6588

Note: Since I don’t speak Chinese, I used a translator and wasn’t able to verify the accuracy of the translation. If there are any mistakes or better ways to phrase it, feel free to suggest edits or let me know, and I’ll update it accordingly.