### PR TITLE
change set_optimize("small") to "smallest" in configure-targets.md

### DIFF
--- a/docs/guide/project-configuration/configure-targets.md
+++ b/docs/guide/project-configuration/configure-targets.md
@@ -375,11 +375,11 @@ target("lib")
 
 ```lua
 target("app")
-    set_optimize("fast")     -- fast optimization
-    set_optimize("faster")   -- faster optimization
-    set_optimize("fastest")  -- fastest optimization
-    set_optimize("small")    -- size optimization
-    set_optimize("none")     -- no optimization
+    set_optimize("fast")        -- fast optimization
+    set_optimize("faster")      -- faster optimization
+    set_optimize("fastest")     -- fastest optimization
+    set_optimize("smallest")    -- size optimization
+    set_optimize("none")        -- no optimization
 ```
 
 ### Setting Debug Information


### PR DESCRIPTION
When I migrated a project from xmake 2.9 to xmake 3.0 I got warning
```warning: target(xxx): unknown optimize value 'small', it may be 'smallest'```

Then I checked the documentation and found no changes, so here they are.
