### PR TITLE
docs: fix typo os.raise -> os.raiselevel

### DIFF
--- a/docs/zh/api/scripts/builtin-modules/os.md
+++ b/docs/zh/api/scripts/builtin-modules/os.md
@@ -478,7 +478,7 @@ os.raise("an error occurred")
 
 ```lua
 -- 抛出一个带 "an error occurred" 信息的异常
-os.raise(3, "an error occurred")
+os.raiselevel(3, "an error occurred")
 ```
 
 ## os.features


### PR DESCRIPTION
typo os.raise -> os.raiselevel

