### PR TITLE
docs: add missing wdk.sign.digest_algorithm description

### DIFF
--- a/docs/api/description/project-target.md
+++ b/docs/api/description/project-target.md
@@ -2630,6 +2630,7 @@ The following is a list of some built-in extended configuration items currently 
 | wdk.sign.store              | Set wdk code signing store                             |
 | wdk.sign.certfile           | Set wdk code signing certificate file                  |
 | wdk.sign.thumbprint         | Set wdk code signing fingerprint                       |
+| wdk.sign.digest_algorithm   | Set wdk code signing digest algorithm                  |
 
 ## add_values
 

--- a/docs/examples/cpp/wdk.md
+++ b/docs/examples/cpp/wdk.md
@@ -93,6 +93,7 @@ We can use test certificate of xmake to do testsign, but please run `$xmake l ut
 target("msdsm")
     add_rules("wdk.driver", "wdk.env.wdm")
     set_values("wdk.sign.mode", "test")
+    set_values("wdk.sign.digest_algorithm", "sha256")
 ```
 
 Or we set a valid certificate thumbprint to do it in local machine.
@@ -102,6 +103,7 @@ target("msdsm")
     add_rules("wdk.driver", "wdk.env.wdm")
     set_values("wdk.sign.mode", "test")
     set_values("wdk.sign.thumbprint", "032122545DCAA6167B1ADBE5F7FDF07AE2234AAA")
+    set_values("wdk.sign.digest_algorithm", "sha256")
 ```
 
 We can also do testsign via setting store/company info.
@@ -112,6 +114,7 @@ target("msdsm")
     set_values("wdk.sign.mode", "test")
     set_values("wdk.sign.store", "PrivateCertStore")
     set_values("wdk.sign.company", "tboox.org(test)")
+    set_values("wdk.sign.digest_algorithm", "sha256")
 ```
 
 ### ReleaseSign
@@ -124,6 +127,7 @@ target("msdsm")
     set_values("wdk.sign.mode", "release")
     set_values("wdk.sign.company", "xxxx")
     set_values("wdk.sign.certfile", path.join(os.projectdir(), "xxxx.cer"))
+    set_values("wdk.sign.digest_algorithm", "sha256")
 ```
 
 ## Support Low-version System

--- a/docs/zh/api/description/project-target.md
+++ b/docs/zh/api/description/project-target.md
@@ -2600,23 +2600,24 @@ target("test")
 
 下面是一些 xmake 目前支持的一些内置的扩展配置项列表。
 
-| 扩展配置名              | 配置描述                              |
-| ---                     | ---                                   |
-| fortran.moduledir       | 设置 fortran 模块的输出目录           |
-| ndk.arm_mode            | 设置 ndk 的 arm 编译模式（arm/thumb） |
-| objc.build.arc          | 设置启用或禁用 objc 的 arc            |
-| objc++.build.arc        | 设置启用或禁用 objc++ 的 arc          |
-| xcode.bundle_identifier | 设置 xcode 工具链的 Bundle Identifier |
-| xcode.mobile_provision  | 设置 xcode 工具链的证书信息           |
-| xcode.codesign_identity | 设置 xcode 工具链的代码签名标识       |
-| wasm.preloadfiles       | 设置 wasm 打包的预加载文件（preload file） |
-| wdk.env.winver          | 设置 wdk 的 win 支持版本              |
-| wdk.umdf.sdkver         | 设置 wdk 的 umdf sdk 版本             |
-| wdk.kmdf.sdkver         | 设置 wdk 的 kmdf sdk 版本             |
-| wdk.sign.mode           | 设置 wdk 的代码签名模式               |
-| wdk.sign.store          | 设置 wdk 的代码签名 store             |
-| wdk.sign.certfile       | 设置 wdk 的代码签名证书文件           |
-| wdk.sign.thumbprint     | 设置 wdk 的代码签名指纹               |
+| 扩展配置名                 | 配置描述                                 |
+| ---                       | ---                                     |
+| fortran.moduledir         | 设置 fortran 模块的输出目录               |
+| ndk.arm_mode              | 设置 ndk 的 arm 编译模式 (arm/thumb)      |
+| objc.build.arc            | 设置启用或禁用 objc 的 arc                |
+| objc++.build.arc          | 设置启用或禁用 objc++ 的 arc              |
+| xcode.bundle_identifier   | 设置 xcode 工具链的 Bundle Identifier    |
+| xcode.mobile_provision    | 设置 xcode 工具链的证书信息               |
+| xcode.codesign_identity   | 设置 xcode 工具链的代码签名标识            |
+| wasm.preloadfiles         | 设置 wasm 打包的预加载文件 (preload file) |
+| wdk.env.winver            | 设置 wdk 的 win 支持版本                 |
+| wdk.umdf.sdkver           | 设置 wdk 的 umdf sdk 版本                |
+| wdk.kmdf.sdkver           | 设置 wdk 的 kmdf sdk 版本                |
+| wdk.sign.mode             | 设置 wdk 的代码签名模式                   |
+| wdk.sign.store            | 设置 wdk 的代码签名 store                 |
+| wdk.sign.certfile         | 设置 wdk 的代码签名证书文件                |
+| wdk.sign.thumbprint       | 设置 wdk 的代码签名指纹                   |
+| wdk.sign.digest_algorithm | 设置 wdk 的代码签名摘要算法                |
 
 ## add_values
 

--- a/docs/zh/examples/cpp/wdk.md
+++ b/docs/zh/examples/cpp/wdk.md
@@ -93,6 +93,7 @@ $ xmake [p|package] -o outputdir
 target("msdsm")
     add_rules("wdk.driver", "wdk.env.wdm")
     set_values("wdk.sign.mode", "test")
+    set_values("wdk.sign.digest_algorithm", "sha256")
 ```
 
 不过这种情况下，需要用户手动在管理员模式下，执行一遍：`$xmake l utils.wdk.testcert install`，来生成和注册test证书到本机环境。
@@ -107,6 +108,7 @@ target("msdsm")
     add_rules("wdk.driver", "wdk.env.wdm")
     set_values("wdk.sign.mode", "test")
     set_values("wdk.sign.thumbprint", "032122545DCAA6167B1ADBE5F7FDF07AE2234AAA")
+    set_values("wdk.sign.digest_algorithm", "sha256")
 ```
 
 从store/company来选择合适的证书进行签名：
@@ -117,6 +119,7 @@ target("msdsm")
     set_values("wdk.sign.mode", "test")
     set_values("wdk.sign.store", "PrivateCertStore")
     set_values("wdk.sign.company", "tboox.org(test)")
+    set_values("wdk.sign.digest_algorithm", "sha256")
 ```
 
 ### 正式签名 {#sign}
@@ -129,6 +132,7 @@ target("msdsm")
     set_values("wdk.sign.mode", "release")
     set_values("wdk.sign.company", "xxxx")
     set_values("wdk.sign.certfile", path.join(os.projectdir(), "xxxx.cer"))
+    set_values("wdk.sign.digest_algorithm", "sha256")
 ```
 
 ## 生成低版本驱动 {#low-version-driver}

--- a/docs/zh/posts/support-wdk.md
+++ b/docs/zh/posts/support-wdk.md
@@ -198,6 +198,7 @@ $ xmake [p|package] -o outputdir
 target("msdsm")
     add_rules("wdk.driver", "wdk.env.wdm")
     set_values("wdk.sign.mode", "test")
+    set_values("wdk.sign.digest_algorithm", "sha256")
     add_files("src/*.c")
 ```
 
@@ -211,6 +212,7 @@ target("msdsm")
     add_rules("wdk.driver", "wdk.env.wdm")
     set_values("wdk.sign.mode", "test")
     set_values("wdk.sign.thumbprint", "032122545DCAA6167B1ADBE5F7FDF07AE2234AAA")
+    set_values("wdk.sign.digest_algorithm", "sha256")
     add_files("src/*.c")
 ```
 
@@ -222,6 +224,7 @@ target("msdsm")
     set_values("wdk.sign.mode", "test")
     set_values("wdk.sign.store", "PrivateCertStore")
     set_values("wdk.sign.company", "tboox.org(test)")
+    set_values("wdk.sign.digest_algorithm", "sha256")
     add_files("src/*.c")
 ```
 
@@ -235,6 +238,7 @@ target("msdsm")
     set_values("wdk.sign.mode", "release")
     set_values("wdk.sign.company", "xxxx")
     set_values("wdk.sign.certfile", path.join(os.projectdir(), "xxxx.cer"))
+    set_values("wdk.sign.digest_algorithm", "sha256")
 ```
 
 ## 生成低版本驱动


### PR DESCRIPTION
The wdk.sign.digest_algorithm field was previously undocumented. This commit adds its description to clarify its role in specifying the hash algorithm used during driver signing.