### PR TITLE
Replace `pacman -Sy` with `pacman -S` in Arch Linux installation guides

### DIFF
--- a/docs/guide/quick-start.md
+++ b/docs/guide/quick-start.md
@@ -85,8 +85,8 @@ brew install xmake
 
 ::: code-group
 
-```sh [Archlinux]
-sudo pacman -Sy xmake
+```sh [Arch Linux]
+sudo pacman -S xmake
 ```
 
 ```sh [Alpine]

--- a/docs/zh/guide/quick-start.md
+++ b/docs/zh/guide/quick-start.md
@@ -87,8 +87,8 @@ brew install xmake
 
 ::: code-group
 
-```sh [Archlinux]
-sudo pacman -Sy xmake
+```sh [Arch Linux]
+sudo pacman -S xmake
 ```
 
 ```sh [Alpine]


### PR DESCRIPTION
According to [ArchWiki](https://wiki.archlinux.org/title/System_maintenance#Partial_upgrades_are_unsupported), using `pacman -Sy` to perform partial upgrades is not supported.

