### PR TITLE
feat(homepage): show live release badge under hero-tagline

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -5,6 +5,9 @@ hero:
   name: "Xmake"
   text: "A cross-platform build utility based on Lua"
   tagline: <i>Modern C/C++ build tools</i>
+    <a href="https://github.com/xmake-io/xmake/releases">
+      <img src="https://img.shields.io/github/release/xmake-io/xmake.svg?style=plastic&prefix=v&color=42b883&logo=lua" alt="Github All Releases" />
+    </a>
   actions:
     - theme: brand
       text: Get Started ->

--- a/docs/zh/index.md
+++ b/docs/zh/index.md
@@ -5,6 +5,9 @@ hero:
   name: "Xmake"
   text: "一个基于Lua的轻量级跨平台自动构建工具"
   tagline: <i>现代化的 C/C++ 构建工具</i>
+    <a href="https://github.com/xmake-io/xmake/releases">
+      <img src="https://img.shields.io/github/release/xmake-io/xmake.svg?style=plastic&prefix=v&color=42b883&logo=lua" alt="Github All Releases" />
+    </a>
   actions:
     - theme: brand
       text: 快速上手 ->


### PR DESCRIPTION
Add a real-time version number badge to the homepage of the xmake official website to make it easier for users to see the current version number.

English
<img width="1749" height="1079" alt="image" src="https://github.com/user-attachments/assets/1cee1d7d-00a7-4f4e-918e-216832f5f10b" />

简体中文
<img width="1754" height="1110" alt="image" src="https://github.com/user-attachments/assets/20a8431f-99e4-499e-b4a2-17f19c0314a3" />
