### PR TITLE
docs: document add_moduleresolver

### DIFF
--- a/docs/api/description/global-interfaces.md
+++ b/docs/api/description/global-interfaces.md
@@ -350,6 +350,112 @@ add_moduledirs(os.projectdir() .. "/modules")
 ```
 xmake will load the given module in the given directory when calling [`import`](/api/scripts/builtin-modules/import).
 
+## add_moduleresolver
+
+### Add a custom module resolver
+
+#### Function Prototype
+
+::: tip API
+```lua
+add_moduleresolver(resolver: <function>)
+```
+:::
+
+
+#### Parameter Description
+
+| Parameter | Description |
+|-----------|-------------|
+| resolver | Module resolver callback function |
+
+#### Usage
+
+In addition to loading modules from module directories added by [`add_moduledirs`](#add-moduledirs), we can also register custom module resolvers.
+
+A module resolver is a fallback provider for [`import`](/api/scripts/builtin-modules/import). It is called only after normal module lookup fails, so existing built-in modules and modules found in configured module directories still take precedence.
+
+The resolver receives the requested module name and a resolver context object.
+
+```lua
+add_moduleresolver(function (name, ctx)
+    if name == "virtual.hello" then
+        return ctx.module({
+            hello = function ()
+                return "hello"
+            end
+        })
+    end
+
+    return ctx.miss()
+end)
+```
+
+Then we can import the module normally.
+
+```lua
+local hello = import("virtual.hello", {anonymous = true})
+print(hello.hello())
+```
+
+This is useful for generated modules, virtual modules, test modules, or project-specific module providers that do not map directly to static Lua files in a module directory.
+
+#### Resolver result helpers
+
+The resolver context provides the following helper functions.
+
+| Helper | Description |
+|--------|-------------|
+| `ctx.file(path)` | Resolves the module to a Lua file path. The file is loaded through the normal module loader. |
+| `ctx.module(exports)` | Resolves the module to an in-memory module export table. |
+| `ctx.miss()` | Skips the current resolver and allows later resolvers, or the normal import failure path, to continue. |
+
+#### Resolve to a generated file
+
+If a project generates a Lua module on demand, the resolver can return the generated file with `ctx.file`.
+
+```lua
+add_moduleresolver(function (name, ctx)
+    if name == "generated.hello" then
+        local modulefile = path.join(os.tmpdir(), "generated", "hello.lua")
+
+        os.mkdir(path.directory(modulefile))
+        io.writefile(modulefile, [[
+function hello()
+    return "hello from generated module"
+end
+]])
+
+        return ctx.file(modulefile)
+    end
+
+    return ctx.miss()
+end)
+
+local hello = import("generated.hello", {anonymous = true})
+print(hello.hello())
+```
+
+#### Resolution order
+
+Custom module resolvers are fallback providers. The resolution order is:
+
+1. normal module lookup, including built-in modules and directories added by [`add_moduledirs`](#add-moduledirs)
+2. registered module resolvers, in registration order
+3. normal import failure
+
+This preserves existing module lookup behavior and avoids accidentally shadowing existing modules.
+
+#### Cache behavior
+
+Resolver results are cached by the requested module name, like normal imported modules.
+
+If we want to force a module to be resolved again, we can use `nocache` with `import`.
+
+```lua
+local hello = import("generated.hello", {anonymous = true, nocache = true})
+```
+
 ## add_plugindirs
 
 ### Add plugin directories

--- a/docs/api/description/global-interfaces.md
+++ b/docs/api/description/global-interfaces.md
@@ -350,7 +350,7 @@ add_moduledirs(os.projectdir() .. "/modules")
 ```
 xmake will load the given module in the given directory when calling [`import`](/api/scripts/builtin-modules/import).
 
-## add_moduleresolver
+## add_moduleresolver {#add-moduleresolver}
 
 ### Add a custom module resolver
 

--- a/docs/api/scripts/builtin-modules/import.md
+++ b/docs/api/scripts/builtin-modules/import.md
@@ -76,6 +76,7 @@ The import mechanism is as follows:
 
 1. Import from the current script directory first
 2. Import from the extended class library
+3. If normal module lookup fails, try custom module resolvers registered by [`add_moduleresolver`](/api/description/global-interfaces#add-moduleresolver)
 
 Imported grammar rules:
 
@@ -149,6 +150,36 @@ Version 2.1.5 adds two new properties: `import("xxx.xxx", {try = true, anonymous
 
 If the try is true, the imported module does not exist, only return nil, and will not interrupt xmake after throwing an exception.
 If anonymous is true, the imported module will not introduce the current scope, only the imported object reference will be returned in the import interface.
+
+### Custom module resolvers
+
+In addition to loading modules from the current script directory, the extended class library, or directories configured by [`add_moduledirs`](/api/description/global-interfaces#add-moduledirs), projects can register custom module resolvers with [`add_moduleresolver`](/api/description/global-interfaces#add-moduleresolver).
+
+A module resolver is a fallback provider. It is called only after normal module lookup fails, so existing built-in modules and modules found in configured module directories still take precedence.
+
+For example, a resolver can provide a virtual module:
+
+```lua
+add_moduleresolver(function (name, ctx)
+    if name == "virtual.hello" then
+        return ctx.module({
+            hello = function ()
+                return "hello"
+            end
+        })
+    end
+    return ctx.miss()
+end)
+```
+
+Then we can import it normally:
+
+```lua
+local hello = import("virtual.hello", {anonymous = true})
+print(hello.hello())
+```
+
+Resolvers can also provide generated Lua module files by returning `ctx.file(path)`. For more details, see [`add_moduleresolver`](/api/description/global-interfaces#add-moduleresolver).
 
 ## Custom extension module
 

--- a/docs/api/scripts/builtin-modules/import.md
+++ b/docs/api/scripts/builtin-modules/import.md
@@ -151,7 +151,7 @@ Version 2.1.5 adds two new properties: `import("xxx.xxx", {try = true, anonymous
 If the try is true, the imported module does not exist, only return nil, and will not interrupt xmake after throwing an exception.
 If anonymous is true, the imported module will not introduce the current scope, only the imported object reference will be returned in the import interface.
 
-### Custom module resolvers
+### Custom module resolvers {#custom-module-resolvers}
 
 In addition to loading modules from the current script directory, the extended class library, or directories configured by [`add_moduledirs`](/api/description/global-interfaces#add-moduledirs), projects can register custom module resolvers with [`add_moduleresolver`](/api/description/global-interfaces#add-moduleresolver).
 


### PR DESCRIPTION
Documents the new `add_moduleresolver(...)` API proposed in xmake-io/xmake#7566 and implemented in the related Xmake PR.

This adds:

- `add_moduleresolver(...)` to the global interfaces page
- resolver result helpers: `ctx.file(...)`, `ctx.module(...)`, and `ctx.miss()`
- resolver fallback behavior and resolution order
- resolver cache behavior with `nocache`
- a short note in the `import(...)` docs explaining that custom resolvers are tried after normal module lookup fails

Related:

- Feature request: https://github.com/xmake-io/xmake/issues/7566
- Xmake implementation PR:  https://github.com/xmake-io/xmake/pull/7569