### PR TITLE
Fix Zig c++ error

### DIFF
--- a/docs/guide/basic-commands/switch-toolchains.md
+++ b/docs/guide/basic-commands/switch-toolchains.md
@@ -356,7 +356,7 @@ $ xmake
 We can also use the `zig cc` compiler provided by zig to compile C/C++ code.
 
 ```sh
-$ xmake f --cc="zig cc" --cxx="zig cc" --ld="zig c++" -c
+$ xmake f --cc="zig cc" --cxx="zig c++" --ld="zig c++" -c
 $ xmake
 ```
 


### PR DESCRIPTION
The instructions for cross-compiling with Zig had one mistake on them: --cxx should be "zig c++" and not "zig cc"

* Before adding new features and new modules, please go to issues to submit the relevant feature description first.
* Write good commit messages and use the same coding conventions as the rest of the project.
* Please commit code to dev branch and we will merge into master branch in feature
* Ensure your edited codes with four spaces instead of TAB.

------

* 增加新特性和新模块之前，请先到issues提交相关特性说明，经过讨论评估确认后，再进行相应的代码提交，避免做无用工作。
* 编写友好可读的提交信息，并使用与工程代码相同的代码规范，代码请用4个空格字符代替tab缩进。
* 请提交代码到dev分支，如果通过，我们会在特定时间合并到master分支上。
* 为了规范化提交日志的格式，commit消息，不要用中文，请用英文描述。

